### PR TITLE
sregistry Singularity bootstrap definition file

### DIFF
--- a/Singularity
+++ b/Singularity
@@ -20,6 +20,6 @@ git clone -b development https://www.github.com/vsoch/singularity-python
 cd singularity-python
 /opt/conda/bin/pip install setuptools
 /opt/conda/bin/pip install -r requirements.txt
-/opt/conda/bin/pip install pyasn1==0.3.2
+/opt/conda/bin/pip install pyasn1==0.3.4
 /opt/conda/bin/python setup.py sdist
 /opt/conda/bin/python setup.py install

--- a/Singularity
+++ b/Singularity
@@ -3,7 +3,7 @@ From: continuumio/miniconda3
 
 %runscript
 
-exec /usr/local/bin/sregistry "$@"
+exec /opt/conda/bin/sregistry "$@"
 
 %labels
 maintainer vsochat@stanford.edu


### PR DESCRIPTION
Minor changes on sregistry Singularity bootstrap definition file: Change pyasn1 version from 0.3.2 to 0.3.4

I tried to create the image with v0.3.2 and it fails. With v0.3.4 seems to work at least in my case.