### PR TITLE
Dockerfile adds gsettings.m4, fixes build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ ENV PYTHONUNBUFFERED 1
 RUN apt-get update && apt-get install -y \
     anacron \
     libopenblas-dev \
+    libglib2.0-dev \
     gfortran \
     pkg-config \
     libxml2-dev \


### PR DESCRIPTION
The only idea coming to mind why on this end the build fails but not for @vsoch and friends are differences between the dynamically assigned Debian mirrors that depend on where one is located. That line fixed it (except that I had it on a separate RUN apt-get ... invocation).