### PR TITLE
Allowing for private (authenticated pull) of images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
 ## [v1.x](https://github.com/singularityhub/singularity-python/tree/development) (development)
 
 **changed defaults**
+ - changed internal functions to use sregistry client (instead of singularity)
+ - authentication check added to sregistry pull, so private images can be pulled given correct credentials
  - from the *sregistry client* provided by Singularity Python, to support use of squashfs images and singularity 2.4, the default upload is not compressed, assuming squashfs, and the default download is not decompressed. To still compress an image add the `--compress` flag on push, and the `--decompress` flag on pull.
 
 **bugs fixed**

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ django-chosen
 opbeat
 django-hstore==1.3.5
 django-datatables-view
--e git+https://github.com/singularityware/singularity-python.git@1b38684fcda7931885269488e16305f989147b4f#egg=singularity
+sregistry
 django-gravatar2
 pygments
 google-api-python-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ django-chosen
 opbeat
 django-hstore==1.3.5
 django-datatables-view
-sregistry
+sregistry==0.0.5
 django-gravatar2
 pygments
 google-api-python-client

--- a/shub/apps/api/actions/delete.py
+++ b/shub/apps/api/actions/delete.py
@@ -20,7 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 '''
 
 from shub.logger import bot
-from singularity.registry.auth import generate_timestamp
+from sregistry.auth import generate_timestamp
 from shub.apps.api.utils import validate_request
 
 

--- a/shub/apps/api/actions/push.py
+++ b/shub/apps/api/actions/push.py
@@ -27,7 +27,7 @@ from rest_framework.viewsets import ModelViewSet
 from shub.apps.api.models import ImageFile
 from rest_framework import serializers
 from shub.apps.api.utils import validate_request
-from singularity.registry.auth import generate_timestamp
+from sregistry.auth import generate_timestamp
 
 class ContainerPushSerializer(serializers.HyperlinkedModelSerializer):
 

--- a/shub/apps/api/utils.py
+++ b/shub/apps/api/utils.py
@@ -28,7 +28,7 @@ from rest_framework.permissions import (
     Http404
 )
 
-from singularity.utils import write_file
+from sregistry.utils import write_file
 from shub.apps.users.models import User
 
 from datetime import datetime, timezone

--- a/shub/apps/logs/utils.py
+++ b/shub/apps/logs/utils.py
@@ -21,7 +21,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
 from shub.apps.main.models import Container
-from singularity.utils import read_json
+from sregistry.utils import read_json
 from shub.settings import MEDIA_ROOT
 
 from itertools import chain
@@ -40,7 +40,7 @@ def get_request_collection(instance):
     instance: should be an APIRequestLog object, with a response
               and path to parse
     '''
-    from singularity.registry.utils import parse_image_name
+    from sregistry.utils import parse_image_name
     from shub.apps.main.models import Collection 
     
     try: 

--- a/shub/apps/main/query.py
+++ b/shub/apps/main/query.py
@@ -21,7 +21,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
 from shub.apps.main.models import Container, Collection
-from singularity.registry.utils import parse_image_name
+from sregistry.utils import parse_image_name
 from shub.logger import bot
 from django.db.models import Q
 import os

--- a/shub/apps/main/utils.py
+++ b/shub/apps/main/utils.py
@@ -23,7 +23,7 @@ from datetime import timedelta
 from django.utils import timezone
 
 from shub.apps.main.models import Container
-from singularity.utils import read_json
+from sregistry.utils import read_json
 from shub.settings import MEDIA_ROOT
 
 from itertools import chain

--- a/shub/apps/main/views/collections.py
+++ b/shub/apps/main/views/collections.py
@@ -25,7 +25,7 @@ from shub.apps.main.models import (
     Star
 )
 
-from singularity.utils import read_file
+from sregistry.utils import read_file
 from shub.apps.users.views import validate_credentials
 from django.shortcuts import (
     render, 

--- a/shub/apps/users/templates/users/token.html
+++ b/shub/apps/users/templates/users/token.html
@@ -26,12 +26,14 @@
                    <i class="fa fa-copy"></i></button>
        </div>
        <div style="padding-top:20px; overflow:scroll;" class="well col-md-11" id="token_well" role="alert">
-            {  "token": 
+            { "registry": {
+                "token": 
                      "{{ request.user.token }}",
                 "username": "{{ request.user.username }}"{% if domain %},{% endif %} 
                 {% if domain %}
                 "base": "{{ domain }}"
                 {% endif %}
+               }
             }
        </div>
     </div>


### PR DESCRIPTION
This PR will do the following:
 - updates the sregistry to use the sregistry client from this this PR: https://github.com/singularityhub/sregistry-cli/pull/32 Note that although the PR isn't merged, the client version (0.0.5) has been pushed to pypi. @victorsndvg when you test, make sure to install this verison 0.0.5 from pypi.
 - **important** the structure of the credential provided has been changed (to allow for the other clients). Instead of a flat file:

```
{'token': '1234' ..}
```
it's now nested under registry

```
{ 'registry'' { token': '1234' .. } }
```
so @victorsndvg - you will need to go to the web interface to get the updated token data structure, upload it at $HOME/.sregistry (and this is the format that this PR for sregistry and the client version 0.0.5 are expecting).

@victorsndvg would you like to test this branch and then report back? Specifically, we should do the following:

1. pull this branch and use it to update your local registry
2. go to the token page in the registry and copy paste the newly formatted token to your `$HOME/.sregistry` file
3. Install the version of sregistry from pip (should be 0.0.5) both locally for your client, and for your containers (or for any singularity images you use with the client).
4. test the pull, report back

When we have confirmed all looks good, I'll merge both PRs! Note that although sregistry 0.0.5 is on pypi it hasn't been merged either.