### PR TITLE
removing admin role in favor of is_staff

### DIFF
--- a/shub/apps/api/utils.py
+++ b/shub/apps/api/utils.py
@@ -95,7 +95,7 @@ def validate_request(auth,
         return False
 
     if superuser is True:
-        if user.admin is False:
+        if user.is_staff is False:
             bot.debug('User %s is not a superuser, request invalid.' %user.username)
             return False
 

--- a/shub/apps/base/templates/base/navigation.html
+++ b/shub/apps/base/templates/base/navigation.html
@@ -48,7 +48,7 @@
                 <li role="separator" class="divider"></li>
                 <!--<li class="dropdown-header">Settings</li>-->
                 <li><a href="/api">API</a></li>
-                {% if request.user.admin %}
+                {% if request.user.is_staff %}
                 <li><a href="{% url 'token' %}">Token</a></li>
                 {% endif %}
                 <li><a href="{% url 'logout' %}">Log Out</a></li>

--- a/shub/apps/main/models.py
+++ b/shub/apps/main/models.py
@@ -75,7 +75,7 @@ def has_edit_permission(instance,request):
         return False
 
     # Global Admins
-    if request.user.admin is True:
+    if request.user.is_staff is True:
         return True
 
     if request.user.is_superuser is True:
@@ -101,7 +101,7 @@ def has_view_permission(instance,request):
         return False
         
     # Global Admins
-    if request.user.admin is True or request.user.is_superuser:
+    if request.user.is_staff is True or request.user.is_superuser:
         return True
 
     # Collection Contributors

--- a/shub/apps/main/views/compare.py
+++ b/shub/apps/main/views/compare.py
@@ -96,7 +96,7 @@ def get_filtered_collections(request):
     '''
     private = True
     if not request.user.is_anonymous():
-        if request.user.is_superuser or request.user.admin is True:
+        if request.user.is_superuser or request.user.is_staff is True:
              private = True
 
     if not private:

--- a/shub/apps/users/management/commands/add_admin.py
+++ b/shub/apps/users/management/commands/add_admin.py
@@ -49,10 +49,10 @@ class Command(BaseCommand):
         except User.DoesNotExist:
             raise CommandError("This username does not exist.")
 
-        if user.admin is True: #and user.manager is True:
+        if user.is_staff is True: #and user.manager is True:
             raise CommandError("This user can already manage and build.")        
 
-        user.admin = True
+        user.is_staff = True
         #user.manager = True
         user.save()
         bot.debug("%s can now manage and build." %(user.username))

--- a/shub/apps/users/management/commands/remove_admin.py
+++ b/shub/apps/users/management/commands/remove_admin.py
@@ -49,10 +49,10 @@ class Command(BaseCommand):
         except User.DoesNotExist:
             raise CommandError("This username does not exist.")
 
-        if user.admin is False: #and user.manager is False:
+        if user.is_staff is False: #and user.manager is False:
             raise CommandError("This user already can't manage and build.")        
 
-        user.admin = False
+        user.is_staff = False
         #user.manager = False
         bot.debug("%s can no longer manage and build." %(user.username))
         user.save()

--- a/shub/apps/users/models.py
+++ b/shub/apps/users/models.py
@@ -20,11 +20,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 '''
 
 from django.conf import settings
-from django.contrib.auth import get_user_model
-from django.core.exceptions import ValidationError
 from django.db.models.signals import post_save
 from django.dispatch import receiver
-from django.contrib.postgres.fields import JSONField
 from rest_framework.authtoken.models import Token
 from shub.apps.users.utils import get_usertoken
 from django.contrib.auth.models import AbstractUser
@@ -38,7 +35,6 @@ import re
 
 class User(AbstractUser):
     active = models.BooleanField(default=True)         # allowed to build, etc.
-    admin = models.BooleanField(default=False)         # is this a registry admin?
     agree_terms = models.BooleanField(default=False)   # has the user agreed to terms?
     agree_terms_date = models.DateTimeField(blank=True,default=None,null=True)          # has the user agreed to terms?
     

--- a/shub/apps/users/templates/users/token.html
+++ b/shub/apps/users/templates/users/token.html
@@ -8,7 +8,7 @@
 {% block content %}
 <div id="fh5co-portfolio">
 
-    {% if request.user.admin and not request.user.is_anonymous %}
+    {% if request.user.is_staff and not request.user.is_anonymous %}
     <div class="row" style='padding-bottom:30px'>
         <h2>API Token</h2>
         <small>push to the Registry</small>

--- a/shub/apps/users/views/users.py
+++ b/shub/apps/users/views/users.py
@@ -27,7 +27,7 @@ from django.shortcuts import render, redirect
 
 @login_required
 def view_token(request):
-    if request.user.is_superuser or request.user.admin is True:
+    if request.user.is_superuser or request.user.is_staff is True:
         return render(request, 'users/token.html')
     else:
         messages.info(request,"You are not allowed to perform this action.")

--- a/shub/settings/dummy_secrets.py
+++ b/shub/settings/dummy_secrets.py
@@ -106,9 +106,6 @@
 
 # AUTH_LDAP_USER_FLAGS_BY_GROUP = {
 
-#     # Not currently used, will be added to indicate active/not
-#    "is_active": "cn=active,ou=django,ou=groups,dc=example,dc=com",
-#
 #    # Anyone in this group can get a token to manage images, not superuser
 #    "is_staff": "cn=staff,ou=django,ou=groups,dc=example,dc=com",
 #

--- a/shub/settings/dummy_secrets.py
+++ b/shub/settings/dummy_secrets.py
@@ -101,6 +101,18 @@
 
 # Map LDAP group membership into Django admin flags
 #AUTH_LDAP_USER_FLAGS_BY_GROUP = {
-#    # Anyone in this group is a superuser for the app
 #    "is_superuser": "cn=sregistry_admin,ou=groups,dc=example,dc=com"
 #}
+
+# AUTH_LDAP_USER_FLAGS_BY_GROUP = {
+
+#     # Not currently used, will be added to indicate active/not
+#    "is_active": "cn=active,ou=django,ou=groups,dc=example,dc=com",
+#
+#    # Anyone in this group can get a token to manage images, not superuser
+#    "is_staff": "cn=staff,ou=django,ou=groups,dc=example,dc=com",
+#
+#    # Anyone in this group is a superuser for the app
+#    "is_superuser": "cn=superuser,ou=django,ou=groups,dc=example,dc=com"
+
+# }


### PR DESCRIPTION
This will remove the `admin` boolean stored with a user in favor of the standard `is_staff` which is a much better option, since it's a django default. See here https://github.com/singularityhub/sregistry/issues/73#issuecomment-360592999 for discussion, and @dctrud and @victorsndvg looking for your feedback on this!