### PR TITLE
Address #82 large container pulls with download streaming

### DIFF
--- a/shub/apps/api/models.py
+++ b/shub/apps/api/models.py
@@ -85,6 +85,9 @@ class ImageFile(models.Model):
     def get_label(self):
         return "imagefile"
 
+    def get_abspath(self):
+        return os.path.join(settings.MEDIA_ROOT, self.datafile.name)
+
     class Meta:
         app_label = 'api'
 

--- a/shub/apps/main/views/download.py
+++ b/shub/apps/main/views/download.py
@@ -99,18 +99,11 @@ def download_share(request,cid,secret):
     if secret != share.secret:
         raise Response(status.HTTP_401_UNAUTHORIZED)
 
-    # If we make it here, link is good
-    filename = container.get_download_name()
-
-    f = open(container.image.get_abspath(), 'rb')
-    response = FileResponse(f, content_type='application/img')
-    response['Content-Disposition'] = 'attachment; filename="%s"' %filename
-    
-    return response
+    return _download_container(container)
 
 
 
-def download_container(request,cid,secret):
+def download_container(request, cid, secret):
     '''download a container
     '''
     container = get_container(cid)
@@ -119,10 +112,28 @@ def download_container(request,cid,secret):
     if container.secret != secret:
         return Http404
 
-    filename = container.get_download_name()
+    return _download_container(container)
 
-    f = open(container.image.get_abspath(), 'rb')
+
+def _download_container(container):
+    '''
+       download_container is the shared function between downloading a share
+       or a direct container download. For each, we create a FileResponse
+       with content type application/img, and stream it to the container's
+       download name. A FileResponse is returned.
+
+       Parameters
+       ==========
+       container: the container to download
+
+    '''
+
+    filename = container.get_download_name()
+    filepath = container.image.get_abspath()
+
+    f = open(filepath, 'rb')
     response = FileResponse(f, content_type='application/img')
     response['Content-Disposition'] = 'attachment; filename="%s"' %filename
+    response['Content-Length'] = os.path.getsize(filepath)
 
     return response

--- a/shub/apps/main/views/download.py
+++ b/shub/apps/main/views/download.py
@@ -35,7 +35,8 @@ from django.shortcuts import (
 
 from django.http import (
     JsonResponse,
-    HttpResponse
+    HttpResponse,
+    FileResponse
 )
 
 from shub.apps.main.utils import (
@@ -100,9 +101,11 @@ def download_share(request,cid,secret):
 
     # If we make it here, link is good
     filename = container.get_download_name()
-    response = HttpResponse(container.image.datafile.file,
-                            content_type='application/img')
+
+    f = open(container.image.get_abspath(), 'rb')
+    response = FileResponse(f, content_type='application/img')
     response['Content-Disposition'] = 'attachment; filename="%s"' %filename
+    
     return response
 
 
@@ -117,7 +120,9 @@ def download_container(request,cid,secret):
         return Http404
 
     filename = container.get_download_name()
-    response = HttpResponse(container.image.datafile.file,
-                            content_type='application/img')
+
+    f = open(container.image.get_abspath(), 'rb')
+    response = FileResponse(f, content_type='application/img')
     response['Content-Disposition'] = 'attachment; filename="%s"' %filename
+
     return response

--- a/shub/settings/__init__.py
+++ b/shub/settings/__init__.py
@@ -3,6 +3,7 @@ from importlib import import_module
 from .applications import *
 from .config import *
 from .main import *
+from .logging import *
 from .auth import *
 from .api import *
 from .tasks import *

--- a/shub/settings/logging.py
+++ b/shub/settings/logging.py
@@ -1,0 +1,17 @@
+# Default Django logging is WARNINGS+ to console
+# so visible via docker-compose logs uwsgi
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['console'],
+            'level': os.getenv('DJANGO_LOG_LEVEL', 'WARNING'),
+        },
+    },
+}

--- a/shub/settings/logging.py
+++ b/shub/settings/logging.py
@@ -1,3 +1,25 @@
+'''
+
+Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
+University.
+
+This program is free software: you can redistribute it and/or modify it
+under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or (at your
+option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+'''
+
+import os
+
 # Default Django logging is WARNINGS+ to console
 # so visible via docker-compose logs uwsgi
 LOGGING = {

--- a/shub/settings/main.py
+++ b/shub/settings/main.py
@@ -128,7 +128,29 @@ STATIC_URL = '/static/'
 GRAVATAR_DEFAULT_IMAGE = "retro"
 # An image url or one of the following: 'mm', 'identicon', 'monsterid', 'wavatar', 'retro'. Defaults to 'mm'
 
+
+# Default Django logging is WARNINGS+ to console
+# so visible via docker-compose logs uwsgi
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['console'],
+            'level': os.getenv('DJANGO_LOG_LEVEL', 'WARNING'),
+        },
+    },
+}
+
+
 try:
     from .secrets import *
 except ImportError:
     pass
+
+

--- a/shub/settings/main.py
+++ b/shub/settings/main.py
@@ -129,25 +129,6 @@ GRAVATAR_DEFAULT_IMAGE = "retro"
 # An image url or one of the following: 'mm', 'identicon', 'monsterid', 'wavatar', 'retro'. Defaults to 'mm'
 
 
-# Default Django logging is WARNINGS+ to console
-# so visible via docker-compose logs uwsgi
-LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'handlers': {
-        'console': {
-            'class': 'logging.StreamHandler',
-        },
-    },
-    'loggers': {
-        'django': {
-            'handlers': ['console'],
-            'level': os.getenv('DJANGO_LOG_LEVEL', 'WARNING'),
-        },
-    },
-}
-
-
 try:
     from .secrets import *
 except ImportError:

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -6,7 +6,5 @@ socket = :3031
 chdir = /code/
 post-buffering = true
 log-date = true
-harakiri = 20
-harakiri-verbose = true
 max-requests = 5000
 wsgi-file = shub/wsgi.py


### PR DESCRIPTION
This PR is to address #82 - there are 3 changes:

- 682bba3 sets up the Django logger to direct WARNING and above to console by default, so Django errors can then be seen with `docker-compose logs uwsgi`. This is critical to effectively debug download issues that are occuring in Django code. The logs coming out of UWSGI alone are not enough.

- 3690bac uses the Django `FileResponse` class to serve a container download without requiring it to be read entirely into RAM. Note that underneath this is going to use `wsgi.filewrapper` as we are running via UWSGI. `FileResponse` is a convenience (vs using the filewrapper and StreamingHttpResponse directly) that was introduced in newish Django versions. We can't use a `with ... as f` context yet, as context manager support for `File.open` was added in Django 2.0 and we are using 1.11

- bf1e505 disables harakiri for UWSGI. Since we are serving large files via the app/UWSGI we don't know how long is reasonable for a request - there may be a slow connection, a multi GB download could take hours. Auto-kill of unusually long running UWSGI reqests would be appropriate if we further offload serving downloads using xsendfile so that the download itself is handled by nginx, and not our UWSGI  app.