### PR TITLE
updating sregistry to version 0.0.74

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ represented by the pull requests that fixed them. Critical items to know are:
  - changed behaviour (recipe sections work differently)
 
 
-## [v1.x](https://github.com/singularityhub/singularity-python/tree/master) (master)
+## [master](https://github.com/singularityhub/singularity-python/tree/master) (master)
 
+ - updating sregistry-cli to version 0.0.74
  - superusers and admins (global) can now create collections via a button in the interface
  - demos and customizated supplementary content removed - not used
  - user customization possible by superusers in the admin panel

--- a/docs/pages/setup.md
+++ b/docs/pages/setup.md
@@ -183,6 +183,10 @@ Tacosaurus Computing Center is a Singularity Registry to provide institution lev
 
 ```
 
+At this point, you can send this file to `@vsoch` and she will be happy to add your 
+registry to the... registry! If you want to customize your robot image, or submit
+the file yourself via a pull request, continue reading!
+
 ### 3. Choose your image
 For the image and thumbnail, we have a [database of robots](https://vsoch.github.io/robots) that we have randomly selected a robot for you. If you don't like your robot, feel free to browse and choose a different one. Importantly, you will need to add the robot to the github repo:
 

--- a/docs/pages/setup.md
+++ b/docs/pages/setup.md
@@ -144,7 +144,9 @@ cd containers
 ```
 
 ### 2. Generate your Metadata
-Then use the manager to generate a markdown file for your registry:
+Then use the manager to generate a markdown file for your registry. In this example, we have 
+interactively shelled inside the `uwsgi` image for our sregistry like `docker run -it <container> bash` 
+and are sitting in the `/code` folder.
 
 ```
 # Inside the image
@@ -153,7 +155,7 @@ $ python manage.py register
 Registry template written to taco-registry.md!
 
 Your robot is at https://vsoch.github.io/robots/assets/img/robots/robot5413.png
-1. Fork and clone https://www.github.com/singularityhub/sregistry
+1. Fork and clone https://www.github.com/singularityhub/containers
 2. Add taco-registry.md to the registries folder
 3. Download your robot (or add custom institution image) under assets/img/[custom/robots]
 4. Submit a PR to validate your registry.

--- a/https/nginx.conf.https
+++ b/https/nginx.conf.https
@@ -20,6 +20,7 @@ server {
   location / {
     include /etc/nginx/uwsgi_params.par;
     uwsgi_pass uwsgi:3031;
+    uwsgi_max_temp_file_size 10024m;
   }
 
   location /static {
@@ -33,8 +34,8 @@ server {
         server_name localhost;
 
         root html;
-        client_max_body_size 2000M;
-        client_body_buffer_size 2000M;
+        client_max_body_size 8000M;
+        client_body_buffer_size 8000M;
 
         ssl on;
         ssl_certificate /etc/ssl/certs/chained.pem;
@@ -57,6 +58,7 @@ server {
         location / {
             include /etc/nginx/uwsgi_params.par;
             uwsgi_pass uwsgi:3031;
+            uwsgi_max_temp_file_size 10024m;
         }
 
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -20,6 +20,7 @@ server {
   location / {
     include /etc/nginx/uwsgi_params.par;
     uwsgi_pass uwsgi:3031;
+    uwsgi_max_temp_file_size 10024m;
   }
 
   location /static {

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ django-chosen
 opbeat
 django-hstore==1.3.5
 django-datatables-view
-sregistry==0.0.74
+sregistry[registry]==0.0.74
 django-gravatar2
 pygments
 google-api-python-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ django-chosen
 opbeat
 django-hstore==1.3.5
 django-datatables-view
-sregistry==0.0.5
+sregistry==0.0.74
 django-gravatar2
 pygments
 google-api-python-client

--- a/shub/apps/api/actions/delete.py
+++ b/shub/apps/api/actions/delete.py
@@ -20,7 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 '''
 
 from shub.logger import bot
-from sregistry.auth import generate_timestamp
+from sregistry.main.registry.auth import generate_timestamp
 from shub.apps.api.utils import validate_request
 
 

--- a/shub/apps/api/actions/push.py
+++ b/shub/apps/api/actions/push.py
@@ -31,7 +31,7 @@ from shub.apps.api.utils import (
     has_permission, 
     get_request_user
 )
-from sregistry.auth import generate_timestamp
+from sregistry.main.registry.auth import generate_timestamp
 
 class ContainerPushSerializer(serializers.HyperlinkedModelSerializer):
 

--- a/shub/apps/api/urls/containers.py
+++ b/shub/apps/api/urls/containers.py
@@ -26,7 +26,7 @@ from rest_framework.exceptions import (
 )
 
 from shub.apps.api.utils import validate_request
-from sregistry.auth import generate_timestamp
+from sregistry.main.registry.auth import generate_timestamp
 
 from django.urls import reverse
 from django.http import Http404

--- a/shub/apps/base/management/commands/register.py
+++ b/shub/apps/base/management/commands/register.py
@@ -73,7 +73,7 @@ class Command(BaseCommand):
         bot.info("Registry template written to %s!" %outfile)
         bot.newline()
         bot.info("Your robot is at https://vsoch.github.io/robots/assets/img/robots/robot%s.png" %number)
-        bot.info("1. Fork and clone https://www.github.com/singularityhub/sregistry")
+        bot.info("1. Fork and clone https://www.github.com/singularityhub/containers")
         bot.info("2. Add %s to the registries folder" %outfile)
         bot.info("3. Download your robot (or add custom institution image) under assets/img/[custom/robots]")
         bot.info("4. Submit a PR to validate your registry.")


### PR DESCRIPTION
This PR will update the sregistry version, and specify installation of the registry module to ensure requests_toolbelt and the timestamp generation functions are installed. Notably, we in the api and url functions we move the timestamp generation function into the registry module as they are no longer in a global auth.