### PR TITLE
Correct weird sentence

### DIFF
--- a/docs/pages/plugins/globus/README.md
+++ b/docs/pages/plugins/globus/README.md
@@ -80,7 +80,7 @@ the owner of the endpoint. The user will have to further authenticate from the a
 ## Usage
 
 ### Authentication
-Once your server is setup with an endpoint, any logged in user The individual user must authenticate with Globus in order to issue a refresh token to make transfers. To add this integration, do the following:
+Once your server is setup with an endpoint, any logged in user must authenticate with Globus in order to issue a refresh token to make transfers. To add this integration, do the following:
 
  1. When you are logged in, you can access your Integrations under Settings in your user menu:
 


### PR DESCRIPTION
Hello,

I'm not a globus user, but I'm reading the PDF. The first sentence in Usage > Authentication sounds phony:

> Once your server is setup with an endpoint, any logged in user The individual user must authenticate with Globus in order to issue a refresh token to make transfers. To add this integration, do the following: