### PR TITLE
updating nginx push to allow longer filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ represented by the pull requests that fixed them. Critical items to know are:
 
 
 ## [master](https://github.com/singularityhub/singularity-python/tree/master) (master)
+ - increasing length of name limit to 500, and catching error (with message and cleanup)
  - adding Globus integration
  - updating sregistry-cli to version 0.0.74
  - superusers and admins (global) can now create collections via a button in the interface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ represented by the pull requests that fixed them. Critical items to know are:
 
 
 ## [master](https://github.com/singularityhub/singularity-python/tree/master) (master)
+ - updating sregistry-cli to 0.0.96, and Singularity download url to use sylabs organization
  - increasing length of name limit to 500, and catching error (with message and cleanup)
  - adding Globus integration
  - updating sregistry-cli to version 0.0.74

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update && apt-get install -y \
     build-essential
 
 # Install Singularity
-RUN git clone -b vault/release-2.5 https://www.github.com/singularityware/singularity.git
+RUN git clone -b vault/release-2.5 https://www.github.com/sylabs/singularity.git
 WORKDIR singularity
 RUN ./autogen.sh && ./configure --prefix=/usr/local && make && make install
 

--- a/docs/pages/install/settings.md
+++ b/docs/pages/install/settings.md
@@ -38,17 +38,17 @@ One thing I (@vsoch) can't do for you in advance is produce application keys and
 ```
 # Which social auths do you want to use?
 ENABLE_GOOGLE_AUTH=False
-ENABLE_TWITTER_AUTH=True
-ENABLE_GITHUB_AUTH=False
+ENABLE_TWITTER_AUTH=False
+ENABLE_GITHUB_AUTH=True
 ENABLE_GITLAB_AUTH=False
 
 ```
 
-and you will need at least one to log in. I've found that Twitter works the fastest and easiest, and then Github and Google. All avenues are extremely specific with regard to callback urls, so you should be very careful in setting them up. 
+and you will need at least one to log in. I've found that Github works the fastest and easiest, and then Google. Twitter now requires an actual server name and won't work with localost, but if you are deploying on a server with a proper domain go ahead and use it. All avenues are extremely specific with regard to callback urls, so you should be very careful in setting them up. 
 
 Other authentication methods, such as LDAP, are implemented as [plugins](https://singularityhub.github.io/sregistry/plugins/) to sregistry. See the [plugins documentation](https://singularityhub.github.io/sregistry/plugins/) for details on how to configure these.
 
-We will walk through the setup of each in detail. For all of the below, you should put the content in your `secrets.py` under settings. Note that if you are deploying locally, you will need to put localhost (127.0.0.1) as your domain, and Twitter was the only one that worked reliably without an actual domain for me.
+We will walk through the setup of each in detail. For all of the below, you should put the content in your `secrets.py` under settings. Note that if you are deploying locally, you will need to put localhost (127.0.0.1) as your domain, and Github is now the only one that worked reliably without an actual domain for me.
 
 
 #### Google OAuth2
@@ -106,13 +106,15 @@ SOCIAL_AUTH_GITLAB_API_URL = 'https://example.com'
 
 
 #### Setting up Twitter OAuth2
-Twitter is the easiest of the three to setup, you can go to the [Twitter Apps](https://apps.twitter.com/) dashboard, register an app, and add secrets, etc. to your `secrets.py`:
+You can go to the [Twitter Apps](https://apps.twitter.com/) dashboard, register an app, and add secrets, etc. to your `secrets.py`:
 
       SOCIAL_AUTH_TWITTER_KEY = ''
       SOCIAL_AUTH_TWITTER_SECRET = ''
 
 
-The callback url here should be `http://127.0.0.1/complete/twitter`.
+Note that Twitter now does not accept localhost urls. Thus, 
+the callback url here should be `http://[your-domain]/complete/twitter`.
+
 
 
 ### Config

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cython
 h5py
 uwsgi
-Django==1.11.2
+Django==1.11.15
 social-auth-app-django
 social-auth-core[saml]
 python-social-auth

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ django-chosen
 opbeat
 django-hstore==1.3.5
 django-datatables-view
-sregistry==0.0.76
+sregistry==0.0.96
 django-gravatar2
 pygments
 google-api-python-client

--- a/shub/apps/api/actions/__init__.py
+++ b/shub/apps/api/actions/__init__.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/api/actions/create.py
+++ b/shub/apps/api/actions/create.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/api/actions/create.py
+++ b/shub/apps/api/actions/create.py
@@ -23,6 +23,7 @@ from shub.settings import MEDIA_ROOT
 from sregistry.utils import parse_image_name
 from shub.logger import bot
 from django.db import IntegrityError
+from django.db.utils import DataError
 import shutil
 import uuid
 import json
@@ -114,11 +115,20 @@ def upload_container(cid, user, name, version, upload_id, size=None):
         else:
             instance = move_upload_to_storage(collection, upload_id)
 
-        image = ImageFile.objects.create(collection=collection,
-                                         tag=names['tag'],
-                                         name=names['uri'],
-                                         owner_id=user.id,
-                                         datafile=instance.file)
+        # Return an error to the user if the file is too big
+        try:
+            image = ImageFile.objects.create(collection=collection,
+                                             tag=names['tag'],
+                                             name=names['uri'],
+                                             owner_id=user.id,
+                                             datafile=instance.file)
+        # Filename upper limit is 255
+        except DataError as err:
+            message = '%s\n%s must be less than 255 characters' %(err, 
+                                                                  instance.file)
+            bot.error(message)
+            delete_file_instance(instance)
+            return message
 
         # Get a container, if it exists (and the user is re-using a name)
         # Filter by negative id so we get the more recent container first.

--- a/shub/apps/api/actions/delete.py
+++ b/shub/apps/api/actions/delete.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/api/actions/push.py
+++ b/shub/apps/api/actions/push.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/api/actions/push.py
+++ b/shub/apps/api/actions/push.py
@@ -50,6 +50,8 @@ def collection_auth_check(request):
     tag=body.get('tag','latest')                                   
     name=body.get('name')
     collection_name = format_collection_name(body.get('collection'))
+
+    print(tag, name, collection_name, auth, body)
     
     # Authentication always required for push
     if auth is None:
@@ -63,6 +65,7 @@ def collection_auth_check(request):
                                     tag)
 
     # Validate Payload
+    print(payload)
     if not validate_request(auth, payload, "push", timestamp):
         raise PermissionDenied(detail="Unauthorized")
 

--- a/shub/apps/api/actions/upload.py
+++ b/shub/apps/api/actions/upload.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/api/models.py
+++ b/shub/apps/api/models.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
@@ -85,7 +83,9 @@ class ImageFile(models.Model):
     metadata = models.TextField(default='') # will be converted to json
     name = models.CharField(max_length=200, null=False)
     owner_id = models.CharField(max_length=200, null=True)
-    datafile = models.FileField(upload_to=get_upload_folder, storage=OverwriteStorage())
+    datafile = models.FileField(upload_to=get_upload_folder,
+                                max_length=255,
+                                storage=OverwriteStorage())
 
     def get_label(self):
         return "imagefile"

--- a/shub/apps/api/tasks.py
+++ b/shub/apps/api/tasks.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/api/urls/collections.py
+++ b/shub/apps/api/urls/collections.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/api/urls/containers.py
+++ b/shub/apps/api/urls/containers.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/api/urls/labels.py
+++ b/shub/apps/api/urls/labels.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/api/urls/registry.py
+++ b/shub/apps/api/urls/registry.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/api/urls/routers.py
+++ b/shub/apps/api/urls/routers.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/api/urls/serializers.py
+++ b/shub/apps/api/urls/serializers.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/api/urls/swagger.py
+++ b/shub/apps/api/urls/swagger.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/api/utils.py
+++ b/shub/apps/api/utils.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/base/context_processors.py
+++ b/shub/apps/base/context_processors.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/base/management/commands/register.py
+++ b/shub/apps/base/management/commands/register.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/base/sitemap.py
+++ b/shub/apps/base/sitemap.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/base/urls/base.py
+++ b/shub/apps/base/urls/base.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/base/urls/search.py
+++ b/shub/apps/base/urls/search.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/base/views/errors.py
+++ b/shub/apps/base/views/errors.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/base/views/main.py
+++ b/shub/apps/base/views/main.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/base/views/search.py
+++ b/shub/apps/base/views/search.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/logs/utils.py
+++ b/shub/apps/logs/utils.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/main/models.py
+++ b/shub/apps/main/models.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/main/query.py
+++ b/shub/apps/main/query.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/main/urls/collections.py
+++ b/shub/apps/main/urls/collections.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/main/urls/compare.py
+++ b/shub/apps/main/urls/compare.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/main/urls/containers.py
+++ b/shub/apps/main/urls/containers.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/main/urls/labels.py
+++ b/shub/apps/main/urls/labels.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/main/urls/tags.py
+++ b/shub/apps/main/urls/tags.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/main/utils.py
+++ b/shub/apps/main/utils.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/main/views/__init__.py
+++ b/shub/apps/main/views/__init__.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/main/views/collections.py
+++ b/shub/apps/main/views/collections.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/main/views/compare.py
+++ b/shub/apps/main/views/compare.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/main/views/containers.py
+++ b/shub/apps/main/views/containers.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/main/views/download.py
+++ b/shub/apps/main/views/download.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/main/views/labels.py
+++ b/shub/apps/main/views/labels.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/main/views/share.py
+++ b/shub/apps/main/views/share.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/main/views/stars.py
+++ b/shub/apps/main/views/stars.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/main/views/tags.py
+++ b/shub/apps/main/views/tags.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/singularity/templatetags/to_dash.py
+++ b/shub/apps/singularity/templatetags/to_dash.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/users/admin.py
+++ b/shub/apps/users/admin.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/users/forms.py
+++ b/shub/apps/users/forms.py
@@ -2,23 +2,18 @@
 
 Copyright (c) 2017 Vanessa Sochat
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+This program is free software: you can redistribute it and/or modify it
+under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or (at your
+option) any later version.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+License for more details.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 '''
 

--- a/shub/apps/users/management/commands/add_admin.py
+++ b/shub/apps/users/management/commands/add_admin.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/users/management/commands/add_superuser.py
+++ b/shub/apps/users/management/commands/add_superuser.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/users/management/commands/remove_admin.py
+++ b/shub/apps/users/management/commands/remove_admin.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/users/management/commands/remove_superuser.py
+++ b/shub/apps/users/management/commands/remove_superuser.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/users/models.py
+++ b/shub/apps/users/models.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/users/permissions.py
+++ b/shub/apps/users/permissions.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/users/urls/social.py
+++ b/shub/apps/users/urls/social.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/users/urls/teams.py
+++ b/shub/apps/users/urls/teams.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/users/urls/users.py
+++ b/shub/apps/users/urls/users.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/users/utils.py
+++ b/shub/apps/users/utils.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/users/views/auth.py
+++ b/shub/apps/users/views/auth.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/users/views/teams.py
+++ b/shub/apps/users/views/teams.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/apps/users/views/users.py
+++ b/shub/apps/users/views/users.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/celery.py
+++ b/shub/celery.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/logger.py
+++ b/shub/logger.py
@@ -1,8 +1,6 @@
 '''
 
 Copyright (C) 2017-2018 Vanessa Sochat.
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/shub/plugins/globus/actions.py
+++ b/shub/plugins/globus/actions.py
@@ -1,9 +1,6 @@
 '''
 
 Copyright (C) 2017-2018 Vanessa Sochat.
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
-
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/shub/plugins/globus/decorators.py
+++ b/shub/plugins/globus/decorators.py
@@ -1,9 +1,6 @@
 '''
 
 Copyright (C) 2017-2018 Vanessa Sochat.
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
-
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/shub/plugins/globus/utils.py
+++ b/shub/plugins/globus/utils.py
@@ -2,30 +2,18 @@
 
 Copyright (c) 2017, Vanessa Sochat, All rights reserved.
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+This program is free software: you can redistribute it and/or modify it
+under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or (at your
+option) any later version.
 
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+License for more details.
 
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-
-* Neither the name of the copyright holder nor the names of its
-  contributors may be used to endorse or promote products derived from
-  this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 '''
 

--- a/shub/plugins/globus/views.py
+++ b/shub/plugins/globus/views.py
@@ -1,8 +1,6 @@
 '''
 
 Copyright (C) 2017-2018 Vanessa Sochat.
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/plugins/saml_auth/context_processors.py
+++ b/shub/plugins/saml_auth/context_processors.py
@@ -1,8 +1,6 @@
 '''
 
 Copyright (C) 2017-2018 Vanessa Sochat.
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/shub/plugins/saml_auth/urls.py
+++ b/shub/plugins/saml_auth/urls.py
@@ -1,8 +1,6 @@
 '''
 
 Copyright (C) 2017-2018 Vanessa Sochat.
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/shub/plugins/saml_auth/views.py
+++ b/shub/plugins/saml_auth/views.py
@@ -1,8 +1,6 @@
 '''
 
 Copyright (C) 2017-2018 Vanessa Sochat.
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/shub/settings/api.py
+++ b/shub/settings/api.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/settings/applications.py
+++ b/shub/settings/applications.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/settings/auth.py
+++ b/shub/settings/auth.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/settings/config.py
+++ b/shub/settings/config.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
@@ -23,8 +21,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 # Which social auths do you want to use?
 ENABLE_GOOGLE_AUTH=False
-ENABLE_TWITTER_AUTH=True
-ENABLE_GITHUB_AUTH=False
+ENABLE_TWITTER_AUTH=False
+ENABLE_GITHUB_AUTH=True
 ENABLE_GITLAB_AUTH=False
 
 # NOTE you will need to set autehtication methods up.

--- a/shub/settings/logging.py
+++ b/shub/settings/logging.py
@@ -1,7 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
+Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/shub/settings/main.py
+++ b/shub/settings/main.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/settings/tasks.py
+++ b/shub/settings/tasks.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it

--- a/shub/urls.py
+++ b/shub/urls.py
@@ -1,7 +1,5 @@
 '''
 
-Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
-University.
 Copyright (C) 2017-2018 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it


### PR DESCRIPTION
This will allow for longer filenames for uploaded containers (100 is django file field default, and we will go to 255) and also return a meaningful message to the user if this is violated, cleaning up the instance so another push is possible. This will close #154 