### PR TITLE
Updating error to catch filename error also on OSError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ represented by the pull requests that fixed them. Critical items to know are:
 
 
 ## [master](https://github.com/singularityhub/singularity-python/tree/master) (master)
+ - updating sregistry-cli to 0.0.97, catching OSError earlier
  - updating sregistry-cli to 0.0.96, and Singularity download url to use sylabs organization
  - increasing length of name limit to 500, and catching error (with message and cleanup)
  - adding Globus integration

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ django-chosen
 opbeat
 django-hstore==1.3.5
 django-datatables-view
-sregistry==0.0.96
+sregistry==0.0.97
 django-gravatar2
 pygments
 google-api-python-client


### PR DESCRIPTION
Currently, we catch the "file is too long" error with a DataError when the object is created. The error can be triggered earlier when we try to move the nginx upload to storage, so I've moved this into the try catch, and also am just printing the basename of the file so the user doesn't see where it's being stored. @victorsndvg this should address your concern and it would be great it you might test, and will close #158 