### PR TITLE
Support build-args option - Resolve #218

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,12 @@ ENV PYTHONUNBUFFERED 1
 ENV DEBIAN_FRONTEND noninteractive
 ENV MESSAGELEVEL QUIET
 
+ARG ENABLE_LDAP=false
+ARG ENABLE_PAM=false
+ARG ENABLE_GOOGLEBUILD=false
+ARG ENABLE_GLOBUS=false
+ARG ENABLE_SAML=false
+
 ################################################################################
 # CORE
 # Do not modify this section
@@ -45,21 +51,21 @@ ADD . /code/
 # You are free to uncomment the plugins that you want to use
 
 # Install LDAP (uncomment if wanted)
-# RUN pip install python3-ldap
-# RUN pip install django-auth-ldap
+RUN if $ENABLE_LDAP; then pip install python3-ldap ; fi;
+RUN if $ENABLE_LDAP; then pip install django-auth-ldap ; fi;
 
 # Install PAM Authentication (uncomment if wanted)
-# RUN pip install django-pam
+RUN if $ENABLE_PAM; then pip install django-pam ; fi;
 
 # Ensure Google Build Installed
-# RUN pip install sregistry[google-build]
+RUN if $ENABLE_GOOGLEBUILD; then pip install sregistry[google-build] ; fi;
 
 # Install Globus (uncomment if wanted)
-# RUN /bin/bash /code/scripts/globus/globus-install.sh
+RUN if $ENABLE_GLOBUS; then /bin/bash /code/scripts/globus/globus-install.sh ; fi;
 
 # Install SAML (uncomment if wanted)
-# RUN pip install python3-saml
-# RUN pip install social-auth-core[saml]
+RUN if $ENABLE_SAML; then pip install python3-saml ; fi;
+RUN if $ENABLE_SAML; then pip install social-auth-core[saml] ; fi;
 
 ################################################################################
 # BASE

--- a/docs/_docs/plugins/README.md
+++ b/docs/_docs/plugins/README.md
@@ -25,6 +25,21 @@ your registries' local `shub/settings/secrets.py` file.
  - [SAML](saml): Authentication with SAML
  - [Google Build](google-build) provides build and storage on Google Cloud.
 
+The Dockerfile has some build arguments to build the Docker image according to the plugins software requirements. These variables are set to false by default:
+```bash
+ARG ENABLE_LDAP=false
+ARG ENABLE_PAM=false
+ARG ENABLE_GOOGLEBUILD=false
+ARG ENABLE_GLOBUS=false
+ARG ENABLE_SAML=false
+```
+
+Therefore, if you want to install the requirements of all current supported plugins, you can build the image as follows: 
+```bash
+docker build --build-arg ENABLE_LDAP=true --build-arg ENABLE_PAM=true  --build-arg ENABLE_GOOGLEBUILD=true --build-arg ENABLE_GLOBUS=true --build-arg ENABLE_SAML=true -t vanessa/sregistry .
+```
+
+
 ## Writing a Plugin
 
 An sregistry plugin is a Django App, that lives inside `shub/plugins/<plugin-name>`.
@@ -44,6 +59,10 @@ and `CONTEXT_PROCESSORS` listed in the plugin `__init.py__` is merged into the p
 More documentation will be added as the plugin interface is developed. For now, see plugins
 distrubuted with sregisty under `shub/plugins` for example code.
 
+Besides, if your plugin has any specific software requirements that are not currently available in the Docker image and **those requirements are compatible with the current software**, you can set a new build argument `ENABLE_{PLUGIN_NAME}` and add the corresponding installation commands in the `PLUGINS` section of the Dockerfile with the following format:
+```bash
+RUN if $ENABLE_{PLUGIN_NAME}; then {INSTALLATION_COMMAND}; fi;
+```
 ## Writing Documentation
 Documentation for your plugin is just as important as the plugin itself! You should create a subfolder under
 `docs/pages/plugins/<your-plugin>` with an appropriate README.md that is linked to in this file.

--- a/docs/_docs/plugins/globus/README.md
+++ b/docs/_docs/plugins/globus/README.md
@@ -11,12 +11,6 @@ The `globus` plugin allows a logged in user to connect their Globus account to a
 
 
 ## Setup
-First uncomment the line to install Globus in the Dockerfile.
-
-```bash
-# Install Globus (uncomment if wanted)
-RUN /bin/bash /code/scripts/globus/globus-install.sh
-```
 
 In your `shub/settings/secrets.py` file you need to add a client id and secret generated at [https://developers.globus.org/](https://developers.globus.org/). Navigate to the site and do the following:
 
@@ -52,11 +46,9 @@ SOCIAL_AUTH_GLOBUS_SECRET="xxxxxxxxxxxxxxx"
 ```
 
 If you don't yet have a `secrets.py` you can copy the `dummy_secrets.py` in the same folder, which has commented out examples of the above.
-Then build the container. Given that you have uncommented the line in the Dockerfile, the build
-process will install Globus.
-
+Then, you must build the container setting the build argument ENABLE_GLOBUS to true.
 ```
-docker build -t vanessa/sregistry .
+docker build --build-arg ENABLE_GLOBUS=true -t vanessa/sregistry .
 ```
 
 Once the build is done, start the container.

--- a/docs/_docs/plugins/google_build/README.md
+++ b/docs/_docs/plugins/google_build/README.md
@@ -35,19 +35,10 @@ PLUGINS_ENABLED = [
      'google_build'
 ]
 ```
-
-And uncomment installing the google build client in the Dockerfile:
-
-```bash
-# Ensure Google Build Installed
-# RUN pip install sregistry[google-build]
-```
-
-You will need to build the image locally, with other additional
-changes (usually plugins) you want enabled:
+You will need to build the image locally with, at least, the build argument ENABLE_GOOGLEBUILD set to true:
 
 ```bash
-$ docker build -t vanessa/sregistry .
+$ docker build --build-arg ENABLE_GOOGLEBUILD=true -t vanessa/sregistry .
 ```
 
 ## Secrets

--- a/docs/_docs/plugins/ldap/README.md
+++ b/docs/_docs/plugins/ldap/README.md
@@ -13,7 +13,7 @@ LDAP directory. This supports logins against [Microsoft Active Directory](https:
 
 To enable LDAP authentication you must:
 
-  * Uncomment the Dockerfile section to install LDAP dependencies *before* building the image
+  * Build the docker image with the build argument ENABLE_LDAP set to true
   * Add `ldap_auth` to the `PLUGINS_ENABLED` list in `shub/settings/config.py`
   * Configure the details of your LDAP directory in `shub/settings/secrets.py`. See
     `shub/settings/dummy_secrets.py` for an example OpenLDAP configuration. A good start is to do the following:
@@ -301,6 +301,11 @@ AUTH_LDAP_USER_FLAGS_BY_GROUP = {
 ```
 
 Also ensure 'ldap_auth' is listed in `PLUGINS_ENABLED` inside `shub/settings/config.py`.
+
+Finally, you must build the Docker image with the build argument ENABLE_LDAP set to true:
+```bash
+docker build --build-arg ENABLE_LDAP=true -t vanessa/sregistry . 
+```
 
 It's recommended to have the uwsgi logs open so any issue with ldap is shown clearly. You can do that with:
 

--- a/docs/_docs/plugins/pam/README.md
+++ b/docs/_docs/plugins/pam/README.md
@@ -11,11 +11,9 @@ The `pam_auth` plugin allows users to login to sregistry using the unix accounts
 the host system.
 
 To enable PAM authentication you must:
-
-  * Uncomment the Dockerfile section to install PAM dependencies *before* building the image
   * Add `pam_auth` to the `PLUGINS_ENABLED` list in `shub/settings/config.py`
   * Uncomment binds to /etc/shadow and /etc/passwd in `docker-compose.yml`
-
+  * Build the docker image with the build argument ENABLE_PAM set to true
 More detailed instructions are below.
 
 ## Permissions
@@ -28,14 +26,8 @@ and each user will still each need to export their token to push.  You can read 
 ## Getting Started
 
 This is the detailed walkthough to set up the PAM AUthentication plugin. 
-First, uncomment installation of the module in the Dockerfile:
 
-```bash
-# Install PAM Authentication (uncomment if wanted)
-RUN pip install django-pam
-```
-
-Then, uncomment "pam_auth" at the bottom of `shub/settings/config.py` to 
+First, uncomment "pam_auth" at the bottom of `shub/settings/config.py` to 
 enable the login option.
 
 ```bash
@@ -47,7 +39,7 @@ PLUGINS_ENABLED = [
 ]
 ```
 
-Finally, since we need to get access to users from the host,
+Since we need to get access to users from the host,
 you need to edit the `docker-compose.yml` and uncomment binds to your host:
 
 ```bash
@@ -76,3 +68,8 @@ $ sudo adduser --disabled-login --system --home /var/cache/nginx --ingroup nginx
 
 Note that this solution [would require restarting the container](https://github.com/jupyterhub/jupyterhub/issues/535) for changes on the host to take effect (for example,
 adding new users). If you find a better way to do this, please test and open an issue to add to this documentation.
+
+Finally, you must build the docker image with the build argument ENABLE_PAM set to true:
+```bash
+$ docker build --build-arg ENABLE_PAM=true -t vanessa/sregistry .
+```

--- a/docs/_docs/plugins/saml/README.md
+++ b/docs/_docs/plugins/saml/README.md
@@ -14,12 +14,19 @@ To enable SAML authentication you must:
   * Add `saml_auth` to the `PLUGINS_ENABLED` list in `shub/settings/config.py`
   * Add some configuration detials to `shub/settings/config.py`
   * Configure the details of your SAML provider in in `shub/settings/secrets.py` per instructions provided [here](http://python-social-auth.readthedocs.io/en/latest/backends/saml.html).
+  * Build the docker image with the build argument ENABLE_SAML set to true:
+    ```bash
+    $ docker build --build-arg ENABLE_SAML=true -t vanessa/sregistry .
+    ```
+
 
 If you haven't yet created a secrets.py, a good start is to do the following:
 
 ```
 cp shub/settings/dummy_secrets.py shub/settings/secrets.py
 ```
+
+
   
 ## Quick Start
 This quick start is intended to demonstrate basic functionality of the SAML authentication. 


### PR DESCRIPTION
By using this solution, it is possible to build vanessa/sregistry with the desired plugins requirements. For example, if we want to build with PAM and LDAP authentication, the build command is:
```bash
sudo docker build --build-arg ENABLE_LDAP=true --build-arg ENABLE_PAM=true -t vanessa/sregistry ${path_to_dockerfile}
````