### PR TITLE
Adding default API backend

### DIFF
--- a/shub/settings/api.py
+++ b/shub/settings/api.py
@@ -14,6 +14,7 @@ REST_FRAMEWORK = {
     #'DEFAULT_PERMISSION_CLASSES': (
     #    'rest_framework.permissions.IsAuthenticated',
     #),
+    'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema',
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.SessionAuthentication',


### PR DESCRIPTION
Django restful now needs to know the default API backend view, and I've set this to be coreapi.AutoSchema.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>