### PR TITLE
(maint) update prepare_instance.sh

### DIFF
--- a/scripts/prepare_instance.sh
+++ b/scripts/prepare_instance.sh
@@ -58,15 +58,15 @@ sudo docker run hello-world
 # sudo groupadd docker
 
 #make sure to add all users that will maintain / use the registry
-sudo usermod -aG docker $USER
+sudo usermod -aG docker "$USER"
 
 # Docker-compose
 sudo apt -y install docker-compose
 
 # Note that you will need to log in and out for changes to take effect
 
-if [ ! -d $INSTALL_ROOT/sregistry ]; then
-    cd $INSTALL_ROOT
+if [ ! -d "$INSTALL_ROOT"/sregistry ]; then
+    cd "$INSTALL_ROOT" || exit
 
     # if you need to install a specific branch
     # git clone -b <branch> https://www.github.com/singularityhub/sregistry.git
@@ -74,7 +74,7 @@ if [ ! -d $INSTALL_ROOT/sregistry ]; then
     # otherwise production
     git clone https://www.github.com/singularityhub/sregistry.git
 
-    cd sregistry
+    cd sregistry || exit
     docker build -t quay.io/vanessa/sregistry .
     docker-compose up -d
 fi


### PR DESCRIPTION
- quote variables to avoid globbing

- cd error handling
> cd can fail for a variety of reasons: misspelled paths, missing directories,
> missing permissions, broken symlinks and more. If/when it does, the script will
> keep going and do all its operations in the wrong directory. This can be messy,
> especially if the operations involve creating or deleting a lot of files.