### PR TITLE
(maint) Dockerfile use `COPY` instead of `ADD`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,11 +41,11 @@ RUN apt-get update && apt-get install -y \
     build-essential
 
 # Install Python requirements out of /tmp so not triggered if other contents of /code change
-ADD requirements.txt /tmp/requirements.txt
+COPY requirements.txt /tmp/requirements.txt
 RUN pip install --upgrade pip
 RUN pip install -r /tmp/requirements.txt
 
-ADD . /code/
+COPY . /code/
 
 ################################################################################
 # PLUGINS


### PR DESCRIPTION
- Use `COPY` because it doesn't take advantage of the `ADD` auto `.tar` extraction feature.

Taken from Docker's [Best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy) documentation.

Signed-off-by: Vladislav Doster <mvdoster@gmail.com>