### PR TITLE
(maint) fix anti-patterns and improve performance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,11 +41,11 @@ RUN apt-get update && apt-get install -y \
     build-essential
 
 # Install Python requirements out of /tmp so not triggered if other contents of /code change
-ADD requirements.txt /tmp/requirements.txt
+COPY requirements.txt /tmp/requirements.txt
 RUN pip install --upgrade pip
 RUN pip install -r /tmp/requirements.txt
 
-ADD . /code/
+COPY . /code/
 
 ################################################################################
 # PLUGINS

--- a/scripts/globus/robotnamer.py
+++ b/scripts/globus/robotnamer.py
@@ -201,7 +201,8 @@ class RobotNamer:
         numbers = "".join((self._select(chars) for _ in range(length)))
         return delim.join([descriptor, noun, numbers])
 
-    def _select(self, select_from):
+    @staticmethod
+    def _select(select_from):
         """select an element from a list using random.choice
 
         Parameters

--- a/shub/apps/api/models/__init__.py
+++ b/shub/apps/api/models/__init__.py
@@ -65,7 +65,8 @@ class ImageFile(models.Model):
     owner_id = models.CharField(max_length=200, null=True)
     datafile = models.FileField(upload_to=get_upload_folder, max_length=255)
 
-    def get_label(self):
+    @staticmethod
+    def get_label():
         return "imagefile"
 
     def get_abspath(self):

--- a/shub/apps/api/urls/collections.py
+++ b/shub/apps/api/urls/collections.py
@@ -68,8 +68,7 @@ class CollectionViewSet(viewsets.ReadOnlyModelViewSet):
 class CollectionDetailByName(APIView):
     """Retrieve a collection instance based on it's name"""
 
-    @staticmethod
-    def get_object(collection_name):
+    def get_object(self, collection_name):
         try:
             collection = Collection.objects.get(name=collection_name.lower())
         except Collection.DoesNotExist:
@@ -97,8 +96,7 @@ class CollectionSearch(APIView):
     a general search to look across all fields for one term
     """
 
-    @staticmethod
-    def get_object(query):
+    def get_object(self, query):
         collections = collection_query(query.lower())
         return collections
 

--- a/shub/apps/api/urls/collections.py
+++ b/shub/apps/api/urls/collections.py
@@ -28,7 +28,8 @@ class CollectionSerializer(serializers.HyperlinkedModelSerializer):
 
     containers = serializers.SerializerMethodField("list_containers")
 
-    def list_containers(self, collection):
+    @staticmethod
+    def list_containers(collection):
         container_list = []
         for c in collection.containers.all():
             entry = {
@@ -67,7 +68,8 @@ class CollectionViewSet(viewsets.ReadOnlyModelViewSet):
 class CollectionDetailByName(APIView):
     """Retrieve a collection instance based on it's name"""
 
-    def get_object(self, collection_name):
+    @staticmethod
+    def get_object(collection_name):
         try:
             collection = Collection.objects.get(name=collection_name.lower())
         except Collection.DoesNotExist:
@@ -95,7 +97,8 @@ class CollectionSearch(APIView):
     a general search to look across all fields for one term
     """
 
-    def get_object(self, query):
+    @staticmethod
+    def get_object(query):
         collections = collection_query(query.lower())
         return collections
 

--- a/shub/apps/api/urls/containers.py
+++ b/shub/apps/api/urls/containers.py
@@ -36,20 +36,17 @@ class SingleContainerSerializer(serializers.ModelSerializer):
     image = serializers.SerializerMethodField("get_download_url")
     metadata = serializers.SerializerMethodField("get_cleaned_metadata")
 
-    @staticmethod
-    def collection_name(container):
+    def collection_name(self, container):
         return container.collection.name
 
-    @staticmethod
-    def get_cleaned_metadata(container):
+    def get_cleaned_metadata(self, container):
         metadata = container.metadata
         for key in ["build_metadata", "builder", "build_finish", "image"]:
             if key in metadata:
                 del metadata[key]
         return metadata
 
-    @staticmethod
-    def get_download_url(container):
+    def get_download_url(self, container):
 
         secret = container.collection.secret
         download_url = reverse(
@@ -85,12 +82,10 @@ class ContainerSerializer(serializers.HyperlinkedModelSerializer):
     collection = serializers.SerializerMethodField("collection_name")
     metadata = serializers.SerializerMethodField("get_cleaned_metadata")
 
-    @staticmethod
-    def collection_name(container):
+    def collection_name(self, container):
         return container.collection.name
 
-    @staticmethod
-    def get_cleaned_metadata(container):
+    def get_cleaned_metadata(self, container):
         metadata = container.metadata
         for key in ["build_metadata", "builder", "build_finish", "image"]:
             if key in metadata:
@@ -274,8 +269,7 @@ def _container_get(request, container, name=None, tag=None):
 class ContainerSearch(APIView):
     """search for a list of containers depending on a query"""
 
-    @staticmethod
-    def get_object(name, collection, tag):
+    def get_object(self, name, collection, tag):
         from shub.apps.main.query import specific_container_query
 
         return specific_container_query(name=name, collection=collection, tag=tag)

--- a/shub/apps/api/urls/containers.py
+++ b/shub/apps/api/urls/containers.py
@@ -36,17 +36,20 @@ class SingleContainerSerializer(serializers.ModelSerializer):
     image = serializers.SerializerMethodField("get_download_url")
     metadata = serializers.SerializerMethodField("get_cleaned_metadata")
 
-    def collection_name(self, container):
+    @staticmethod
+    def collection_name(container):
         return container.collection.name
 
-    def get_cleaned_metadata(self, container):
+    @staticmethod
+    def get_cleaned_metadata(container):
         metadata = container.metadata
         for key in ["build_metadata", "builder", "build_finish", "image"]:
             if key in metadata:
                 del metadata[key]
         return metadata
 
-    def get_download_url(self, container):
+    @staticmethod
+    def get_download_url(container):
 
         secret = container.collection.secret
         download_url = reverse(
@@ -82,10 +85,12 @@ class ContainerSerializer(serializers.HyperlinkedModelSerializer):
     collection = serializers.SerializerMethodField("collection_name")
     metadata = serializers.SerializerMethodField("get_cleaned_metadata")
 
-    def collection_name(self, container):
+    @staticmethod
+    def collection_name(container):
         return container.collection.name
 
-    def get_cleaned_metadata(self, container):
+    @staticmethod
+    def get_cleaned_metadata(container):
         metadata = container.metadata
         for key in ["build_metadata", "builder", "build_finish", "image"]:
             if key in metadata:
@@ -269,7 +274,8 @@ def _container_get(request, container, name=None, tag=None):
 class ContainerSearch(APIView):
     """search for a list of containers depending on a query"""
 
-    def get_object(self, name, collection, tag):
+    @staticmethod
+    def get_object(name, collection, tag):
         from shub.apps.main.query import specific_container_query
 
         return specific_container_query(name=name, collection=collection, tag=tag)

--- a/shub/apps/api/urls/labels.py
+++ b/shub/apps/api/urls/labels.py
@@ -26,8 +26,7 @@ class LabelSerializer(serializers.ModelSerializer):
 
     containers = serializers.SerializerMethodField("list_containers")
 
-    @staticmethod
-    def list_containers(label):
+    def list_containers(self, label):
         container_list = []
         for container in label.containers.all():
             container_list.append(container.get_uri())

--- a/shub/apps/api/urls/labels.py
+++ b/shub/apps/api/urls/labels.py
@@ -26,7 +26,8 @@ class LabelSerializer(serializers.ModelSerializer):
 
     containers = serializers.SerializerMethodField("list_containers")
 
-    def list_containers(self, label):
+    @staticmethod
+    def list_containers(label):
         container_list = []
         for container in label.containers.all():
             container_list.append(container.get_uri())
@@ -59,7 +60,8 @@ class LabelViewSet(viewsets.ReadOnlyModelViewSet):
 class LabelDetail(APIView):
     """Retrieve a container instance based on it's name"""
 
-    def get_object(self, key, value):
+    @staticmethod
+    def get_object(key, value):
         # If not specified, return all
         if key is None and value is None:
             return Label.objects.all()

--- a/shub/apps/api/urls/registry.py
+++ b/shub/apps/api/urls/registry.py
@@ -19,7 +19,7 @@ from rest_framework.response import Response
 ################################################################################
 
 
-class Registry(object):
+class Registry:
     def __init__(self, **kwargs):
         self.name = settings.REGISTRY_NAME
         self.id = settings.REGISTRY_URI
@@ -31,14 +31,16 @@ class RegistrySerializer(serializers.Serializer):
     id = serializers.CharField(max_length=256)
     url = serializers.CharField(max_length=256)
 
-    def list(self):
+    @staticmethod
+    def list():
         return Registry()
 
 
 class RegistryViewSet(viewsets.ViewSet):
     serializer_class = RegistrySerializer
 
-    def get_object(self):
+    @staticmethod
+    def get_object():
         return Registry()
 
     def get(self, request):

--- a/shub/apps/api/utils.py
+++ b/shub/apps/api/utils.py
@@ -30,7 +30,7 @@ def _parse_header(auth):
 
     header, content = auth.split(" ")
     content = content.split(",")
-    values = dict()
+    values = {}
     for entry in content:
         key, val = re.split("=", entry, 1)
         values[key] = val

--- a/shub/apps/base/sitemap.py
+++ b/shub/apps/base/sitemap.py
@@ -23,7 +23,8 @@ class BaseSitemap(Sitemap):
 class ContainerSitemap(BaseSitemap):
     changefreq = "weekly"
 
-    def lastmod(self, obj):
+    @staticmethod
+    def lastmod(obj):
         return obj.build_date
 
     def items(self):
@@ -33,7 +34,8 @@ class ContainerSitemap(BaseSitemap):
 class CollectionSitemap(BaseSitemap):
     changefreq = "weekly"
 
-    def lastmod(self, obj):
+    @staticmethod
+    def lastmod(obj):
         return obj.modify_date
 
     def items(self):

--- a/shub/apps/base/sitemap.py
+++ b/shub/apps/base/sitemap.py
@@ -23,8 +23,7 @@ class BaseSitemap(Sitemap):
 class ContainerSitemap(BaseSitemap):
     changefreq = "weekly"
 
-    @staticmethod
-    def lastmod(obj):
+    def lastmod(self, obj):
         return obj.build_date
 
     def items(self):
@@ -34,8 +33,7 @@ class ContainerSitemap(BaseSitemap):
 class CollectionSitemap(BaseSitemap):
     changefreq = "weekly"
 
-    @staticmethod
-    def lastmod(obj):
+    def lastmod(self, obj):
         return obj.modify_date
 
     def items(self):

--- a/shub/apps/base/views/main.py
+++ b/shub/apps/base/views/main.py
@@ -44,8 +44,7 @@ class VersionView(APIView):
 
     renderer_classes = (JSONRenderer,)
 
-    @staticmethod
-    def get(request):
+    def get(self, request):
 
         data = {"version": "v1.0.0", "apiVersion": "2.0.0-alpha.1"}
 

--- a/shub/apps/base/views/main.py
+++ b/shub/apps/base/views/main.py
@@ -44,7 +44,8 @@ class VersionView(APIView):
 
     renderer_classes = (JSONRenderer,)
 
-    def get(self, request):
+    @staticmethod
+    def get(request):
 
         data = {"version": "v1.0.0", "apiVersion": "2.0.0-alpha.1"}
 

--- a/shub/apps/library/views/auth.py
+++ b/shub/apps/library/views/auth.py
@@ -21,7 +21,8 @@ class TokenStatusView(APIView):
 
     renderer_classes = (JSONRenderer,)
 
-    def get(self, request, format=None):
+    @staticmethod
+    def get(request, format=None):
         if validate_token(request):
             return Response(status=200)
         return Response(status=404)
@@ -32,7 +33,8 @@ class GetNamedEntityView(APIView):
 
     renderer_classes = (JSONRenderer,)
 
-    def get(self, request, username):
+    @staticmethod
+    def get(request, username):
 
         print("GET NamedEntityView")
         print(request.query_params)
@@ -65,7 +67,8 @@ class GetEntitiesView(APIView):
 
     renderer_classes = (JSONRenderer,)
 
-    def get(self, request, format=None):
+    @staticmethod
+    def get(request, format=None):
 
         print("GET GetEntitiesView")
 

--- a/shub/apps/library/views/base.py
+++ b/shub/apps/library/views/base.py
@@ -22,7 +22,8 @@ class LibraryBaseView(APIView):
 
     renderer_classes = (JSONRenderer,)
 
-    def get(self, request):
+    @staticmethod
+    def get(request):
 
         user = None
         if not request.user.is_anonymous:

--- a/shub/apps/library/views/helpers.py
+++ b/shub/apps/library/views/helpers.py
@@ -71,7 +71,6 @@ def get_collection_downloads(collection):
     downloads = 0
     for container in collection.containers.all():
         downloads += get_container_downloads(container)
-    return
 
 
 def get_container_downloads(container):
@@ -189,9 +188,9 @@ def generate_collection_tags(collection):
     latest. Technically, collections should be namespaced
     consistently, and we assume this.
     """
-    unique_tags = set(
-        [c.tag for c in collection.containers.all() if not re.search(tag_regex, c.tag)]
-    )
+    unique_tags = {
+        c.tag for c in collection.containers.all() if not re.search(tag_regex, c.tag)
+    }
     tags = {}
 
     for tag in unique_tags:
@@ -266,9 +265,6 @@ def generate_container_metadata(container):
 
     data = {
         "deleted": False,  # 2019-03-15T19:02:24.015Z
-        "createdAt": container.add_date.strftime(
-            formatString
-        ),  # No idea what their format is...
         "createdBy": str(container.collection.owners.first().id),
         "createdAt": container.add_date.strftime(
             formatString

--- a/shub/apps/library/views/images.py
+++ b/shub/apps/library/views/images.py
@@ -71,7 +71,8 @@ class CompletePushImageFileView(RatelimitMixin, APIView):
     renderer_classes = (JSONRenderer,)
     parser_classes = (EmptyParser,)
 
-    def put(self, request, container_id, format=None):
+    @staticmethod
+    def put(request, container_id, format=None):
 
         print("PUT CompletePushImageFileView")
 
@@ -95,7 +96,8 @@ class RequestMultiPartAbortView(RatelimitMixin, APIView):
     renderer_classes = (JSONRenderer,)
     allowed_methods = ("PUT",)
 
-    def put(self, request, upload_id):
+    @staticmethod
+    def put(request, upload_id):
         """In a post, the upload_id will be the container id."""
         print("PUT RequestMultiPartAbortView")
 
@@ -124,7 +126,8 @@ class RequestMultiPartCompleteView(RatelimitMixin, APIView):
     renderer_classes = (JSONRenderer,)
     allowed_methods = ("PUT",)
 
-    def put(self, request, upload_id):
+    @staticmethod
+    def put(request, upload_id):
         """A put is done to complete the upload, providing the image id and number parts
         https://github.com/sylabs/scs-library-client/blob/30f9b6086f9764e0132935bcdb363cc872ac639d/client/push.go#L537
         """
@@ -179,7 +182,8 @@ class RequestMultiPartPushImageFileView(APIView):
     )
     parser_classes = (MultiPartParser, FormParser, JSONParser)
 
-    def put(self, request, upload_id):
+    @staticmethod
+    def put(request, upload_id):
         """After starting the multipart upload continue the process"""
         print("PUT RequestMultiPartPushImageFileView")
 
@@ -254,7 +258,8 @@ class RequestMultiPartPushImageFileView(APIView):
         data = {"presignedURL": signed_url}
         return Response(data={"data": data}, status=200)
 
-    def post(self, request, upload_id):
+    @staticmethod
+    def post(request, upload_id):
         """In a post, the upload_id will be the container id."""
 
         print("POST RequestMultiPartPushImageFileView")
@@ -323,7 +328,8 @@ class RequestPushImageFileView(RatelimitMixin, APIView):
     ratelimit_method = "POST"
     renderer_classes = (JSONRenderer,)
 
-    def post(self, request, container_id, format=None):
+    @staticmethod
+    def post(request, container_id, format=None):
 
         print("POST RequestPushImageFileView")
 
@@ -371,7 +377,8 @@ class PushImageView(RatelimitMixin, APIView):
     ratelimit_method = "GET"
     renderer_classes = (JSONRenderer,)
 
-    def get(self, request, username, collection, name, version):
+    @staticmethod
+    def get(request, username, collection, name, version):
 
         print("GET PushNamedContainerView")
 
@@ -394,7 +401,7 @@ class PushImageView(RatelimitMixin, APIView):
         tag = "DUMMY-%s" % str(uuid.uuid4())
 
         # The container will always be created, and it needs to be handled later
-        container, created = Container.objects.get_or_create(
+        container, _ = Container.objects.get_or_create(
             collection=collection,
             name=name,
             frozen=False,
@@ -420,7 +427,8 @@ class DownloadImageView(RatelimitMixin, APIView):
     ratelimit_block = settings.VIEW_RATE_LIMIT_BLOCK
     ratelimit_method = "GET"
 
-    def get_download_url(self, container):
+    @staticmethod
+    def get_download_url(container):
 
         if "image" in container.metadata:
             return container.metadata["image"]
@@ -431,7 +439,8 @@ class DownloadImageView(RatelimitMixin, APIView):
         )
         return "%s%s" % (settings.DOMAIN_NAME, url)
 
-    def get(self, request, name):
+    @staticmethod
+    def get(request, name):
         print("GET DownloadImageView")
         names = parse_image_name(name)
         container = get_container(names)
@@ -477,7 +486,8 @@ class GetImageView(RatelimitMixin, APIView):
     ratelimit_block = settings.VIEW_RATE_LIMIT_BLOCK
     ratelimit_method = "GET"
 
-    def get(self, request, name):
+    @staticmethod
+    def get(request, name):
 
         # The request specifies ?arch=amd64 but that's all we got
         print("GET GetImageView")
@@ -539,7 +549,8 @@ class CollectionsView(RatelimitMixin, APIView):
     ratelimit_method = ("GET", "POST")
     renderer_classes = (JSONRenderer,)
 
-    def get(self, request):
+    @staticmethod
+    def get(request):
         """Return a simple list of collections.
 
         GET /v1/collections
@@ -554,7 +565,8 @@ class CollectionsView(RatelimitMixin, APIView):
         collections = generate_collections_list(token.user)
         return Response(data=collections, status=200)
 
-    def post(self, request):
+    @staticmethod
+    def post(request):
         """Create a new collection.
 
         POST /v1/collections
@@ -631,7 +643,8 @@ class GetCollectionTagsView(RatelimitMixin, APIView):
     renderer_classes = (JSONRenderer,)
     parser_classes = (EmptyParser,)
 
-    def get(self, request, collection_id):
+    @staticmethod
+    def get(request, collection_id):
 
         print("GET CollectionTagsView")
         if not validate_token(request):
@@ -647,7 +660,8 @@ class GetCollectionTagsView(RatelimitMixin, APIView):
         tags = generate_collection_tags(collection)
         return Response(data={"data": tags}, status=200)
 
-    def post(self, request, collection_id):
+    @staticmethod
+    def post(request, collection_id):
 
         print("POST ContainerTagView")
 
@@ -719,7 +733,8 @@ class ContainersView(RatelimitMixin, APIView):
     ratelimit_method = "GET"
     renderer_classes = (JSONRenderer,)
 
-    def get(self, request):
+    @staticmethod
+    def get(request):
 
         print("GET ContainersView")
         print(request.data)
@@ -746,7 +761,8 @@ class GetNamedCollectionView(RatelimitMixin, APIView):
     ratelimit_method = "GET"
     renderer_classes = (JSONRenderer,)
 
-    def get(self, request, name, username=None):
+    @staticmethod
+    def get(request, name, username=None):
 
         print("GET GetNamedCollectionView")
 
@@ -784,7 +800,8 @@ class GetNamedContainerView(RatelimitMixin, APIView):
     ratelimit_method = "GET"
     renderer_classes = (JSONRenderer,)
 
-    def get(self, request, username, name, container):
+    @staticmethod
+    def get(request, username, name, container):
 
         print("GET GetNamedContainerView")
 

--- a/shub/apps/logs/mixins.py
+++ b/shub/apps/logs/mixins.py
@@ -12,7 +12,7 @@ from rest_framework.authtoken.models import Token
 import traceback
 
 
-class BaseLoggingMixin(object):
+class BaseLoggingMixin:
     logging_methods = "__all__"
 
     """Mixin to log requests"""

--- a/shub/apps/main/models/containers.py
+++ b/shub/apps/main/models/containers.py
@@ -132,7 +132,8 @@ class Container(models.Model):
             return self.image.datafile.file
         return None
 
-    def get_label(self):
+    @staticmethod
+    def get_label():
         return "container"
 
     def __str__(self):

--- a/shub/apps/main/models/shared.py
+++ b/shub/apps/main/models/shared.py
@@ -129,7 +129,8 @@ class Collection(models.Model):
     def get_uri(self):
         return "%s:%s" % (self.name, self.containers.count())
 
-    def get_label(self):
+    @staticmethod
+    def get_label():
         return "collection"
 
     def labels(self):
@@ -138,9 +139,9 @@ class Collection(models.Model):
 
     def container_names(self):
         """return distinct container names"""
-        return list(
-            [x[0] for x in self.containers.values_list("name").distinct() if len(x) > 0]
-        )
+        return [
+            x[0] for x in self.containers.values_list("name").distinct() if len(x) > 0
+        ]
 
     # Permissions
 
@@ -185,7 +186,8 @@ class Star(models.Model):
     user = models.ForeignKey("users.User", on_delete=models.CASCADE)
     collection = models.ForeignKey(Collection, on_delete=models.CASCADE)
 
-    def get_label(self):
+    @staticmethod
+    def get_label():
         return "collection"
 
     class Meta:
@@ -212,7 +214,8 @@ class Share(models.Model):
     def __str__(self):
         return self.container.name
 
-    def get_label(self):
+    @staticmethod
+    def get_label():
         return "main"
 
     class Meta:
@@ -240,7 +243,8 @@ class Label(models.Model):
     def __unicode__(self):
         return "%s:%s" % (self.key, self.value)
 
-    def get_label(self):
+    @staticmethod
+    def get_label():
         return "label"
 
     class Meta:

--- a/shub/apps/main/views/collections.py
+++ b/shub/apps/main/views/collections.py
@@ -117,10 +117,7 @@ def new_collection(request):
 
             messages.info(request, "Collection %s created." % name)
             return redirect("collection_details", cid=collection.id)
-
-        # Just new collection form, not a post
-        else:
-            return render(request, "collections/new_collection.html")
+        return render(request, "collections/new_collection.html")
 
     # If user makes it down here, does not have permission
     messages.info(request, "You don't have permission to perform this action.")

--- a/shub/apps/main/views/compare.py
+++ b/shub/apps/main/views/compare.py
@@ -41,7 +41,7 @@ def generate_size_data(collections):
     flare.analytics.graph.ShortestPaths,5914,9
     flare.analytics.graph.SpanningTree,3416,10
     """
-    data = dict()
+    data = {}
     for collection in collections:
 
         collection_name = collection.name

--- a/shub/apps/main/views/download.py
+++ b/shub/apps/main/views/download.py
@@ -123,7 +123,7 @@ def _download_container(container, request):
         return HttpResponseForbidden()
 
     # A remove build will store a metadata image url
-    elif "image" in container.metadata:
+    if "image" in container.metadata:
 
         if "google_build" in PLUGINS_ENABLED:
             from shub.plugins.google_build.utils import generate_signed_url
@@ -131,7 +131,7 @@ def _download_container(container, request):
             signed_url = generate_signed_url(container.metadata["image"])
 
             # If we can generate a URL, add one to limit and return url
-            if signed_url != None and container.get_count < container.get_limit:
+            if signed_url is not None and container.get_count < container.get_limit:
                 container.get_count += 1
                 container.collection.get_count += 1
                 container.collection.save()
@@ -141,6 +141,4 @@ def _download_container(container, request):
 
         # There is no container
         raise Http404
-
-    else:
-        raise Http404
+    raise Http404

--- a/shub/apps/main/views/download.py
+++ b/shub/apps/main/views/download.py
@@ -139,6 +139,5 @@ def _download_container(container, request):
                 return redirect(signed_url)
             return HttpResponseForbidden()
 
-        # There is no container
-        raise Http404
+    # There is no container
     raise Http404

--- a/shub/apps/main/views/labels.py
+++ b/shub/apps/main/views/labels.py
@@ -27,7 +27,7 @@ from ratelimit.decorators import ratelimit
 
 def get_label(key=None, value=None):
 
-    keyargs = dict()
+    keyargs = {}
     if key is not None:
         keyargs["key"] = key
     if value is not None:

--- a/shub/apps/main/views/tags.py
+++ b/shub/apps/main/views/tags.py
@@ -26,7 +26,7 @@ from .containers import get_container
 
 def get_tag(name=None, tid=None):
 
-    keyargs = dict()
+    keyargs = {}
     if name is not None:
         keyargs["name"] = name
     if tid is not None:

--- a/shub/apps/users/management/commands/add_admin.py
+++ b/shub/apps/users/management/commands/add_admin.py
@@ -39,6 +39,5 @@ class Command(BaseCommand):
 
         if user.is_staff is True:  # and user.manager is True:
             raise CommandError("This user can already manage and build.")
-        else:
-            user = User.objects.add_staff(user)
-            bot.debug("%s can now manage and build." % (user.username))
+        user = User.objects.add_staff(user)
+        bot.debug("%s can now manage and build." % (user.username))

--- a/shub/apps/users/management/commands/add_superuser.py
+++ b/shub/apps/users/management/commands/add_superuser.py
@@ -39,6 +39,5 @@ class Command(BaseCommand):
 
         if user.is_superuser is True:
             raise CommandError("This user is already a superuser.")
-        else:
-            user = User.objects.add_superuser(user)
-            bot.debug("%s is now a superuser." % (user.username))
+        user = User.objects.add_superuser(user)
+        bot.debug("%s is now a superuser." % (user.username))

--- a/shub/apps/users/management/commands/remove_admin.py
+++ b/shub/apps/users/management/commands/remove_admin.py
@@ -39,7 +39,6 @@ class Command(BaseCommand):
 
         if user.is_staff is False:  # and user.manager is False:
             raise CommandError("This user already can't manage and build.")
-        else:
-            user.is_staff = False
-            bot.debug("%s can no longer manage and build." % (user.username))
-            user.save()
+        user.is_staff = False
+        bot.debug("%s can no longer manage and build." % (user.username))
+        user.save()

--- a/shub/apps/users/management/commands/remove_superuser.py
+++ b/shub/apps/users/management/commands/remove_superuser.py
@@ -39,7 +39,6 @@ class Command(BaseCommand):
 
         if user.is_superuser is False:
             raise CommandError("This user already is not a superuser.")
-        else:
-            user.is_superuser = False
-            bot.debug("%s is no longer a superuser." % (user.username))
-            user.save()
+        user.is_superuser = False
+        bot.debug("%s is no longer a superuser." % (user.username))
+        user.save()

--- a/shub/apps/users/models.py
+++ b/shub/apps/users/models.py
@@ -144,7 +144,8 @@ class User(AbstractUser):
         """return a list of providers that the user has credentials for."""
         return [x.provider for x in self.social_auth.all()]
 
-    def get_label(self):
+    @staticmethod
+    def get_label():
         return "users"
 
     @property
@@ -248,7 +249,7 @@ class Team(models.Model):
             return True
 
         # Edit permission to owners given so
-        elif request.user in self.owners.all():
+        if request.user in self.owners.all():
             return True
 
         return False
@@ -275,7 +276,8 @@ class Team(models.Model):
     def __unicode__(self):
         return "%s" % self.name
 
-    def get_label(self):
+    @staticmethod
+    def get_label():
         return "users"
 
     class Meta:
@@ -294,7 +296,8 @@ class MembershipInvite(models.Model):
     def __unicode__(self):
         return "<%s:%s>" % (self.id, self.team.name)
 
-    def get_label(self):
+    @staticmethod
+    def get_label():
         return "users"
 
     def get_url(self):

--- a/shub/apps/users/views/auth.py
+++ b/shub/apps/users/views/auth.py
@@ -36,7 +36,7 @@ def validate_credentials(user, context=None):
     context: an optional context object to append to
     """
     if context is None:
-        context = dict()
+        context = {}
 
     # Right now we have github for repos and google for storage
     credentials = [
@@ -152,7 +152,7 @@ def social_user(backend, uid, user=None, *args, **kwargs):
             msg = "This {0} account is already in use.".format(provider)
             return login(request=backend.strategy.request, message=msg)
             # raise AuthAlreadyAssociated(backend, msg)
-        elif not user:
+        if not user:
             user = social.user
 
     return {

--- a/shub/logger.py
+++ b/shub/logger.py
@@ -66,7 +66,8 @@ class ShubMessage:
                 text = "%s%s%s" % (self.colors[level], text, self.colors["OFF"])
         return text
 
-    def emitError(self, level):
+    @staticmethod
+    def emitError(level):
         """determine if a level should print to
         stderr, includes all levels but INFO and QUIET"""
         if level in [
@@ -82,7 +83,8 @@ class ShubMessage:
             return True
         return False
 
-    def emitOutput(self, level):
+    @staticmethod
+    def emitOutput(level):
         """determine if a level should print to stdout
         only includes INFO"""
         if level in [LOG, INFO]:
@@ -132,7 +134,8 @@ class ShubMessage:
         # Add all log messages to history
         self.history.append(message)
 
-    def write(self, stream, message):
+    @staticmethod
+    def write(stream, message):
         """write will write a message to a stream,
         first checking the encoding
         """

--- a/shub/plugins/globus/utils.py
+++ b/shub/plugins/globus/utils.py
@@ -35,10 +35,10 @@ def list_tokens(tokens):
     This function is first used to populate the Globus social auth
     extra_data field that holds the organized tokens
     """
-    lookup = dict()
+    lookup = {}
     tokens = [tokens] + tokens["other_tokens"]
     for token in tokens:
-        lookup[token["resource_server"]] = dict()
+        lookup[token["resource_server"]] = {}
         for token_type in ["id_token", "refresh_token", "access_token"]:
             if token_type in token:
                 lookup[token["resource_server"]][token_type] = token[token_type]

--- a/shub/plugins/globus/views.py
+++ b/shub/plugins/globus/views.py
@@ -81,11 +81,9 @@ def globus_login(request):
         auth_uri = client.oauth2_get_authorize_url()
         return redirect(auth_uri)
 
-    else:
-
-        # Second step of authentication flow - we need to ask for token
-        code = request.GET.get("code")
-        associate_user(request.user, client=client, code=code)
+    # Second step of authentication flow - we need to ask for token
+    code = request.GET.get("code")
+    associate_user(request.user, client=client, code=code)
 
     return redirect("globus_transfer")
 

--- a/shub/plugins/google_build/github.py
+++ b/shub/plugins/google_build/github.py
@@ -88,8 +88,7 @@ def get_auth_token(user, idx=0):
 
     if len(auth) > idx:
         return auth[idx].access_token
-    else:
-        return auth[0].access_token
+    return auth[0].access_token
 
 
 def get_repo(user, reponame, username, headers=None):

--- a/shub/plugins/google_build/models.py
+++ b/shub/plugins/google_build/models.py
@@ -55,7 +55,8 @@ class RecipeFile(models.Model):
         upload_to=get_upload_folder, max_length=255, storage=OverwriteStorage()
     )
 
-    def get_label(self):
+    @staticmethod
+    def get_label():
         return "recipefile"
 
     def __str__(self):

--- a/shub/plugins/google_build/tasks.py
+++ b/shub/plugins/google_build/tasks.py
@@ -57,7 +57,7 @@ def build_commits(collection, commits, branch):
     collection: The collection to get details for.
     commits: the commits to build.
     """
-    modified = dict()
+    modified = {}
     removed = []
 
     # Find changed files!
@@ -146,7 +146,7 @@ def build_previous_commits(collection, branch):
                 continue
 
             # Only going to build updated recipes
-            elif record["status"] in ["added", "modified", "renamed"]:
+            if record["status"] in ["added", "modified", "renamed"]:
 
                 # Supports building from Singularity recipes
                 if re.search("Singularity", filename):

--- a/shub/plugins/google_build/utils.py
+++ b/shub/plugins/google_build/utils.py
@@ -79,7 +79,7 @@ def paginate(url, headers, min_count=30, start_page=1, params=None, limit=None):
     start_page: the starting page
     """
     if params is None:
-        params = dict()
+        params = {}
     result = []
     result_count = 1000
     page = start_page
@@ -283,7 +283,7 @@ def generate_signed_url(storage_path, expiration=None, headers=None, http_method
     credential = "{}/{}".format(client_email, credential_scope)
 
     if headers is None:
-        headers = dict()
+        headers = {}
     headers["host"] = "storage.googleapis.com"
 
     canonical_headers = ""
@@ -299,7 +299,7 @@ def generate_signed_url(storage_path, expiration=None, headers=None, http_method
         signed_headers += "{};".format(lower_k)
     signed_headers = signed_headers[:-1]  # remove trailing ';'
 
-    query_parameters = dict()
+    query_parameters = {}
     query_parameters["X-Goog-Algorithm"] = "GOOG4-RSA-SHA256"
     query_parameters["X-Goog-Credential"] = credential
     query_parameters["X-Goog-Date"] = request_timestamp

--- a/shub/plugins/google_build/views.py
+++ b/shub/plugins/google_build/views.py
@@ -231,7 +231,7 @@ class RecipePushViewSet(ModelViewSet):
             collection = Collection.objects.get(name=collection_name)
 
             # Only owners can push to existing collections
-            if not owner in collection.owners.all():
+            if owner not in collection.owners.all():
                 print("user not in owners")
                 raise PermissionDenied(detail="Unauthorized")
 

--- a/shub/plugins/pgp/models.py
+++ b/shub/plugins/pgp/models.py
@@ -48,8 +48,7 @@ class PGPKeyModelManager(models.Manager):
         post_save.connect(self.post_save, sender=self.model)
         post_delete.connect(self.post_delete, sender=self.model)
 
-    @staticmethod
-    def post_save(sender, instance, created, **kwargs):
+    def post_save(self, sender, instance, created, **kwargs):
         if created:
             data = instance.file.read()
             pgp = None
@@ -126,8 +125,7 @@ class PGPKeyModelManager(models.Manager):
                         keyid=keyid,
                     )
 
-    @staticmethod
-    def post_delete(sender, instance, **kwargs):
+    def post_delete(self, sender, instance, **kwargs):
         """\sa: self.post_save()"""
         instance.file.delete(False)
 
@@ -182,16 +180,13 @@ class PGPPacketModel(models.Model):
     class Meta:
         abstract = True
 
-    @staticmethod
-    def is_public_key():
+    def is_public_key(self):
         return False
 
-    @staticmethod
-    def is_userid():
+    def is_userid(self):
         return False
 
-    @staticmethod
-    def is_signature():
+    def is_signature(self):
         return False
 
 

--- a/shub/plugins/pgp/models.py
+++ b/shub/plugins/pgp/models.py
@@ -48,7 +48,8 @@ class PGPKeyModelManager(models.Manager):
         post_save.connect(self.post_save, sender=self.model)
         post_delete.connect(self.post_delete, sender=self.model)
 
-    def post_save(self, sender, instance, created, **kwargs):
+    @staticmethod
+    def post_save(sender, instance, created, **kwargs):
         if created:
             data = instance.file.read()
             pgp = None
@@ -125,7 +126,8 @@ class PGPKeyModelManager(models.Manager):
                         keyid=keyid,
                     )
 
-    def post_delete(self, sender, instance, **kwargs):
+    @staticmethod
+    def post_delete(sender, instance, **kwargs):
         """\sa: self.post_save()"""
         instance.file.delete(False)
 
@@ -161,9 +163,9 @@ class PGPKeyModel(models.Model):
 
     def packets(self):
         result = []
-        result += [x for x in self.public_keys.all()]
-        result += [x for x in self.userids.all()]
-        result += [x for x in self.signatures.all()]
+        result += list(self.public_keys.all())
+        result += list(self.userids.all())
+        result += list(self.signatures.all())
         return sorted(result, key=lambda x: x.index)
 
     def ascii_armor(self):
@@ -180,13 +182,16 @@ class PGPPacketModel(models.Model):
     class Meta:
         abstract = True
 
-    def is_public_key(self):
+    @staticmethod
+    def is_public_key():
         return False
 
-    def is_userid(self):
+    @staticmethod
+    def is_userid():
         return False
 
-    def is_signature(self):
+    @staticmethod
+    def is_signature():
         return False
 
 

--- a/shub/plugins/pgp/utils.py
+++ b/shub/plugins/pgp/utils.py
@@ -147,11 +147,10 @@ def is_valid_packets(packets):
 def keys_ascii_armor(keys):
     if keys.count() == 1:
         return keys[0].ascii_armor()
-    else:
-        data = b""
-        for key in keys:
-            data += key.read()
-        return encode_ascii_armor(data)
+    data = b""
+    for key in keys:
+        data += key.read()
+    return encode_ascii_armor(data)
 
 
 def build_machine_readable_indexes(keys):

--- a/shub/plugins/pgp/views.py
+++ b/shub/plugins/pgp/views.py
@@ -96,25 +96,22 @@ def lookup(request):
                 )
                 resp["Content-Disposition"] = 'attachment; filename="pgpkey.asc"'
                 return resp
-            else:
-                resp = HttpResponse(
-                    utils.build_machine_readable_indexes(keys),
-                    content_type="text/plain",
-                )
-                return resp
-        else:
+            resp = HttpResponse(
+                utils.build_machine_readable_indexes(keys),
+                content_type="text/plain",
+            )
+            return resp
 
-            # html response
-            op = op if op else "index"
-            if op == "get":
-                c = {"key": utils.keys_ascii_armor(keys), "search": search}
-                return render(request, "pgpdb/lookup_get.html", c)
-            elif op in ["index", "vindex"]:
-                c = {"keys": keys, "search": search}
-                if op == "index":
-                    return render(request, "pgpdb/lookup_index.html", c)
-                else:
-                    return render(request, "pgpdb/lookup_vindex.html", c)
+        # html response
+        op = op if op else "index"
+        if op == "get":
+            c = {"key": utils.keys_ascii_armor(keys), "search": search}
+            return render(request, "pgpdb/lookup_get.html", c)
+        if op in ["index", "vindex"]:
+            c = {"keys": keys, "search": search}
+            if op == "index":
+                return render(request, "pgpdb/lookup_index.html", c)
+            return render(request, "pgpdb/lookup_vindex.html", c)
 
     except __LookupException:
         content = render(request, "pgpdb/lookup_not_found.html")


### PR DESCRIPTION
- refactor unnecessary `else` / `elif` when `if` block has a `continue` statement
- refactor unnecessary `else` / `elif` when `if` block has a `raise` statement
- refactor unnecessary `else` / `elif` when `if` block has a `return` statement
- remove duplicate dictionary key(s)
- remove unnecessary return statement
- remove unnecessary use of comprehension
- use `_` to denote var is unused

- change methods not using its bound instance to staticmethods

    The method doesn't use its bound instance. Decorate this method with
    @staticmethod decorator, so that Python does not have to instantiate
    a bound method for every instance of this class thereby saving
    memory and computation.

- remove implicit `object` from the base class

    The class is inheriting from object, which is implicit under Python
    3 , hence can be safely removed from bases.

- use literal syntax instead of function calls to create data structure

    This is because here, the name dict must be looked up in the global
    scope in case it has been rebound. The same goes for the other two
    types list() and tuple().

    ```shell In [1]: timeit.timeit(stmt="dict()", number=100000000)
    Out[1]: 9.560388602000103

    In [2]: timeit.timeit(stmt="{}", number=100000000) Out[2]:
    1.685333584000091

    In [3]: timeit.timeit(stmt="tuple()", number=100000000) Out[3]:
    4.509182139000131

    In [4]: timeit.timeit(stmt="()", number=100000000) Out[4]:
    0.5455615430000762

    In [5]: timeit.timeit(stmt="list()", number=100000000) Out[5]:
    7.356000728000254

    In [6]: timeit.timeit(stmt="[]", number=100000000) Out[6]:
    1.573771306999788 ```

- fix membership test

    tests for membership should use the form `x not in the_list` rather
    than `not x in the_list`. the former example is simply more
    readable.

- use set comprehension

    although there is nothing syntactically wrong with this code, it is
    hard to read and can be simplified to a set comprehension. using set
    comprehension is more performant since there is no need to create
    another transient list.

- update singleton comparison

    comparisons to the singleton objects, like true, false, and none,
    should be done with identity, not equality. use “is” or “is not”.
    identity checks are faster than equality checks.

Signed-off-by: Vladislav Doster <mvdoster@gmail.com>