### PR TITLE
Fix SAML Login URL

### DIFF
--- a/shub/apps/users/templates/social/login.html
+++ b/shub/apps/users/templates/social/login.html
@@ -60,7 +60,7 @@
         {% endif %}
 
         {% if 'saml_auth' in PLUGINS_ENABLED %}
-        <a class="social-button" id="saml-connect" href="{% url 'social:begin' 'saml' %}?next={{ request.path }};idp={{ AUTH_SAML_IDP }}">{{ AUTH_SAML_INSTITUTION }} Login</a>
+        <a class="social-button" id="saml-connect" href="{% url 'social:begin' 'saml' %}?next={{ request.path }}&idp={{ AUTH_SAML_IDP }}">{{ AUTH_SAML_INSTITUTION }} Login</a>
         {% endif %}
 
         {% if 'ldap_auth' in PLUGINS_ENABLED %}


### PR DESCRIPTION
For us, the SAML Login URL was being generated with a semi colon rather than an ampersand.

This resulted in an error as detailed in Issue #373 

This change has worked for us.
-Craig
