### PR TITLE
Update minio.py with ssl query

### DIFF
--- a/shub/apps/library/views/minio.py
+++ b/shub/apps/library/views/minio.py
@@ -68,11 +68,15 @@ session = Session(
     region_name=MINIO_REGION,
 )
 
-
+if MINIO_SSL:
+    VERIFY=True
+else:
+    VERIFY=False
+    
 # https://github.com/boto/boto3/blob/develop/boto3/session.py#L185
 s3 = session.client(
     "s3",
-    verify=False,
+    verify=VERIFY,
     use_ssl=MINIO_SSL,
     endpoint_url=MINIO_HTTP_PREFIX + MINIO_SERVER,
     region_name=MINIO_REGION,
@@ -83,10 +87,10 @@ s3 = session.client(
 # https://github.com/boto/botocore/blob/master/botocore/auth.py#L846
 s3_external = session.client(
     "s3",
+    verify=VERIFY,
     use_ssl=MINIO_SSL,
-    region_name=MINIO_REGION,
     endpoint_url=MINIO_HTTP_PREFIX + MINIO_EXTERNAL_SERVER,
-    verify=False,
+    region_name=MINIO_REGION,
     config=Config(signature_version="s3v4", s3={"addressing_style": "path"}),
 )
 


### PR DESCRIPTION
Added a short if-statement to query if SSL is being used in the setup to automatically set the 'verify' attribute of the s3 and s3_external session.client objects.
See https://github.com/singularityhub/sregistry/issues/380 for more information.