### PR TITLE
Enable streamlined upgrades with local.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,8 @@ make_video.sh
 celerybeat-schedule.db
 *.mp4
 OLD
-secrets.py
-local_settings.py
+shub/settings/secrets.py
+shub/settings/local.py
 cronjob
 
 # Static #

--- a/docs/_docs/install/https.md
+++ b/docs/_docs/install/https.md
@@ -83,7 +83,7 @@ The certificate is at "./singularity-registry.org+5.pem" and the key at "./singu
 It will expire on 29 August 2023 🗓
 ```
 
-Then I moved them into the registry root, and updated my shub/settings/config.py to use
+Then I moved them into the registry root, and updated my `shub/settings/local.py` to use
 https on localhost.
 
 ```python

--- a/docs/_docs/install/server.md
+++ b/docs/_docs/install/server.md
@@ -45,8 +45,8 @@ If you don't care about user experience during updates and server downtime, you 
 ## Custom Domain
 
 In the [config settings file](https://github.com/singularityhub/sregistry/blob/master/shub/settings/config.py#L30)
-you'll find a section for domain names, and other metadata about your registry. You will need to update
-this to be a custom hostname that you use, and custom names and unique resource identifiers for your
+you'll find a section for domain names, and other metadata about your registry. You will need to set
+these values in `local.py` to be a custom hostname that you use, and custom names and unique resource identifiers for your
 registry. For example, if you have a Google Domain and are using Google Cloud, you should be able to set it up using [Cloud DNS](https://console.cloud.google.com/net-services/dns/api/enable?nextPath=%2Fzones&project=singularity-static-registry&authuser=1). Usually this means
 creating a zone for your instance, adding a Google Domain, and copying the DNS records for
 the domain into Google Domains. Sometimes it can take a few days for changes to propagate.

--- a/docs/_docs/install/settings.md
+++ b/docs/_docs/install/settings.md
@@ -6,11 +6,15 @@ toc: false
 
 # Settings
 
-See that folder called [settings](https://github.com/singularityhub/sregistry/blob/master/shub/settings)? inside are a bunch of different starting settings for the application. We will change them in these files before we start the application. There are actually only two files you need to poke into, generating a `settings/secrets.py` from our template [settings/dummy_secrets.py](https://github.com/singularityhub/sregistry/blob/master/shub/settings/dummy_secrets.py) for application secrets, and [settings/config.py](https://github.com/singularityhub/sregistry/blob/master/shub/settings/config.py) to configure your database and registry information.
+See that folder called [settings](https://github.com/singularityhub/sregistry/blob/master/shub/settings)? Inside are a bunch of different settings for the application. At a minimum you'll need to set up some minimal secrets and database config before we start the application.
+
+There are actually only two files you need to poke into, generating a `settings/secrets.py` from our template [settings/dummy_secrets.py](https://github.com/singularityhub/sregistry/blob/master/shub/settings/dummy_secrets.py) for application secrets, and [settings/config.py](https://github.com/singularityhub/sregistry/blob/master/shub/settings/config.py) to configure your database and registry information.
+
+Rather than updating the `config.py` file directly, it's recommended you copy the values you want to modify to `settings/local.py`. Values in this file will override anything in the other config files and is an easy way to persist changes across upgrades.
 
 ## Secrets
 
-There should be a file called `secrets.py` in the shub settings folder (it won't exist in the repo, you have to make it), in which you will store the application secret and other social login credentials.
+You will need to create a file called `secrets.py` in the shub settings folder (it won't exist in the repo, you have to make it), in which you will store the application secret and other social login credentials.
 
 An template to work from is provided in the settings folder called `dummy_secrets.py`. You can copy this template:
 
@@ -32,7 +36,7 @@ SECRET_KEY = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
 
 ### Authentication Secrets
 
-One thing I (@vsoch) can't do for you in advance is produce application keys and secrets to give your Registry for each social provider that you want to allow users (and yourself) to login with. We are going to use a framework called [python social auth](https://python-social-auth-docs.readthedocs.io/en/latest/configuration/django.html) to achieve this, and in fact you can add a [number of providers](http://python-social-auth-docs.readthedocs.io/en/latest/backends/index.html) (I have set up a lot of them, including SAML, so please <a href="https://www.github.com/singularityhub/sregistry/isses" target="_blank">submit an issue</a> if you want one added to the base proper.). Singularity Registry uses OAuth2 with a token--> refresh flow because it gives the user power to revoke permission at any point, and is a more modern strategy than storing a database of usernames and passwords. You can enable or disable as many of these that you want, and this is done in the [settings/config.py](https://github.com/singularityhub/sregistry/blob/master/shub/settings/config.py):
+One thing I (@vsoch) can't do for you in advance is produce application keys and secrets to give your Registry for each social provider that you want to allow users (and yourself) to login with. We are going to use a framework called [python social auth](https://python-social-auth-docs.readthedocs.io/en/latest/configuration/django.html) to achieve this, and in fact you can add a [number of providers](http://python-social-auth-docs.readthedocs.io/en/latest/backends/index.html) (I have set up a lot of them, including SAML, so please <a href="https://www.github.com/singularityhub/sregistry/isses" target="_blank">submit an issue</a> if you want one added to the base proper.). Singularity Registry uses OAuth2 with a token--> refresh flow because it gives the user power to revoke permission at any point, and is a more modern strategy than storing a database of usernames and passwords. You can enable or disable as many of these that you want. You can see these settings in the [settings/config.py](https://github.com/singularityhub/sregistry/blob/master/shub/settings/config.py):
 
 
 ```python
@@ -101,7 +105,7 @@ The callback url should be in the format `http://127.0.0.1/complete/github`, and
 
 ### Setting up Github Enterprise OAuth
 
-The GitHub Exterprise [docs are here](https://python-social-auth.readthedocs.io/en/latest/backends/github_enterprise.html).  You will want to register a new application on your instance of GitHub Enterprise in Developer Settings, set the callback URL to "http://example.com/complete/github-enterprise/" replacing example.com with your domain, and then the following environment variables should be defined in your secrets.
+The GitHub Exterprise [docs are here](https://python-social-auth.readthedocs.io/en/latest/backends/github_enterprise.html). You will want to register a new application on your instance of GitHub Enterprise in Developer Settings, set the callback URL to "http://example.com/complete/github-enterprise/" replacing example.com with your domain, and then the following environment variables should be defined in your `secrets.py`.
 
 ```python
 # The URL for your GitHub Enterprise appliance:
@@ -164,7 +168,7 @@ SOCIAL_AUTH_BITBUCKET_OAUTH2_SECRET = '<your-consumer-secret>'
 SOCIAL_AUTH_BITBUCKET_OAUTH2_VERIFIED_EMAILS_ONLY = True
 ```
 
-Finally, don't forget to enable the bitbucket login in settings/config.py:
+Finally, don't forget to enable the bitbucket login in `settings/local.py`:
 
 ```python
 ENABLE_BITBUCKET_AUTH=True
@@ -185,11 +189,11 @@ the callback url here should be `http://[your-domain]/complete/twitter`.
 
 ## Config
 
-In the [config.py](https://github.com/singularityhub/sregistry/blob/master/shub/settings/config.py) you need to define the following:
+Here are some settings you might want to customize for your installation by adding them to `settings/local.py`. You can see the full set of values in [config.py](https://github.com/singularityhub/sregistry/blob/master/shub/settings/config.py) but it's recommended you store changes in `settings/local.py` to persist across upgrades.
 
 ### Google Analytics
 
-If you want to add a Google analytics code, you can do this in the settings/config.py:
+If you want to add a Google analytics code:
 
 ```python
 GOOGLE_ANALYTICS = "UA-XXXXXXXXX"
@@ -199,7 +203,7 @@ The default is set to None, and doesn't add analytics to the registry.
 
 
 ### Domain Name
-A Singularity Registry Server should have a domain. It's not required, but it makes it much easier for yourself and users to remember the address. The first thing you should do is change the `DOMAIN_NAME_*` variables in your settings [settings/config.py](https://github.com/singularityhub/sregistry/blob/master/shub/settings/config.py#L30).
+A Singularity Registry Server should have a domain. It's not required, but it makes it much easier for yourself and users to remember the address. The first thing you should do is set the `DOMAIN_NAME_*` variables in your `settings/local.py` file.
 
 For local testing, you will want to change `DOMAIN_NAME` and `DOMAIN_NAME_HTTP` to be localhost. Also note that I've set the regular domain name (which should be https) to just http because I don't have https locally:
 
@@ -341,7 +345,7 @@ For other disable and limit arguments (for GitHub, creating, or receiving builds
 
 By default, the database itself will be deployed as a postgres image called `db`. You probably don't want this for production (for example, I use a second instance with postgres and a third with a hot backup, but it's an ok solution for a small cluster or single user. Either way, we recommend backing it up every so often.
 
-When your database is set up, you can define it in your `secrets.py` and it will override the Docker image one in the `settings/main.py file`. It should look something like this
+When your database is set up, you can define it in your `local.py`. It should look something like this:
 
 ```python
 DATABASES = {
@@ -366,7 +370,9 @@ LOGGING_SAVE_RESPONSES=True
 ## API
 
 Take a look in [settings/api.py](https://github.com/singularityhub/sregistry/blob/master/shub/settings/api.py)
-to configure your restful API. You can uncomment the first block to require authentication:
+to configure your restful API.
+
+For instance, you add this `local.py` to require authentication:
 
 ```python
   'DEFAULT_PERMISSION_CLASSES': (

--- a/docs/_docs/plugins/README.md
+++ b/docs/_docs/plugins/README.md
@@ -15,9 +15,9 @@ Plugins distributed with `sregistry` are found in the `shub/plugins` directory.
 
 ## Included Plugins
 
-The following plugins are included with sregistry, and can be enabled by adding them to the
-`PLUGINS_ENABLED` entry in `shub/settings/config.py`. Plugins may require further configuration in
-your registries' local `shub/settings/secrets.py` file.
+The following plugins are included with sregistry, and can be enabled by adding them to a
+`PLUGINS_ENABLED` list in `shub/settings/local.py`. See `shub/settings/config.py` for an
+example. Plugins may require further configuration in your local `shub/settings/secrets.py` file.
 
  - [LDAP-Auth](ldap): authentication against LDAP directories
  - [PAM-Auth](pam): authentication using PAM (unix host users)
@@ -54,7 +54,7 @@ Each plugin:
  - Can register additional context processors by defining a tuple of complete paths to the relevant processors by specifying `CONTEXT_PROCESSORS` in its `__init.py__`
  - Must provide a documentation file and link in this README.
 
-Plugins are loaded when the plugin name is added to `PLUGINS_ENABLED` in `shub/settings/config.py`.
+Plugins are loaded when the plugin name is added to `PLUGINS_ENABLED` in `shub/settings/config.py` or `shub/settings/local.py`.
 A plugin mentioned here is added to `INSTALLED_APPS` at runtime, and any `AUTHENTICATION_BACKEND`
 and `CONTEXT_PROCESSORS` listed in the plugin `__init.py__` is merged into the project settings.
 
@@ -65,6 +65,7 @@ Besides, if your plugin has any specific software requirements that are not curr
 ```bash
 RUN if $ENABLE_{PLUGIN_NAME}; then {INSTALLATION_COMMAND}; fi;
 ```
+
 ## Writing Documentation
 Documentation for your plugin is just as important as the plugin itself! You should create a subfolder under
 `docs/pages/plugins/<your-plugin>` with an appropriate README.md that is linked to in this file.

--- a/docs/_docs/plugins/google_build/README.md
+++ b/docs/_docs/plugins/google_build/README.md
@@ -24,14 +24,11 @@ an endpoint.
 ## Configure sregistry
 
 By default, google build is disabled. To configure sregistry to 
-use Google Cloud build and Storage, in settings/config.py you can enable the plugin by 
-uncommenting it from the list here:
+use Google Cloud build and Storage, in `shub/settings/local.py` enable the plugin by
+adding it to a `PLUGINS_ENABLED` list:
 
 ```bash
 PLUGINS_ENABLED = [
-#    'ldap_auth',
-#    'saml_auth',
-#    'globus',
      'google_build'
 ]
 ```

--- a/docs/_docs/plugins/ldap/README.md
+++ b/docs/_docs/plugins/ldap/README.md
@@ -14,7 +14,7 @@ LDAP directory. This supports logins against [Microsoft Active Directory](https:
 To enable LDAP authentication you must:
 
   * Build the docker image with the build argument ENABLE_LDAP set to true
-  * Add `ldap_auth` to the `PLUGINS_ENABLED` list in `shub/settings/config.py`
+  * Add `ldap_auth` to the `PLUGINS_ENABLED` list in `shub/settings/local.py`
   * Configure the details of your LDAP directory in `shub/settings/secrets.py`. See
     `shub/settings/dummy_secrets.py` for an example OpenLDAP configuration. A good start is to do the following:
 
@@ -300,7 +300,7 @@ AUTH_LDAP_USER_FLAGS_BY_GROUP = {
 }
 ```
 
-Also ensure 'ldap_auth' is listed in `PLUGINS_ENABLED` inside `shub/settings/config.py`.
+Also ensure 'ldap_auth' is listed in `PLUGINS_ENABLED` inside `shub/settings/local.py`.
 
 Finally, you must build the Docker image with the build argument ENABLE_LDAP set to true:
 ```bash

--- a/docs/_docs/plugins/pam/README.md
+++ b/docs/_docs/plugins/pam/README.md
@@ -11,7 +11,7 @@ The `pam_auth` plugin allows users to login to sregistry using the unix accounts
 the host system.
 
 To enable PAM authentication you must:
-  * Add `pam_auth` to the `PLUGINS_ENABLED` list in `shub/settings/config.py`
+  * Add `pam_auth` to the `PLUGINS_ENABLED` list in `shub/settings/local.py`
   * Uncomment binds to /etc/shadow and /etc/passwd in `docker compose.yml`
   * Build the docker image with the build argument ENABLE_PAM set to true
 More detailed instructions are below.
@@ -27,15 +27,12 @@ and each user will still each need to export their token to push.  You can read 
 
 This is the detailed walkthough to set up the PAM AUthentication plugin. 
 
-First, uncomment "pam_auth" at the bottom of `shub/settings/config.py` to 
-enable the login option.
+First, add a `PLUGINS_ENABLED` setting in `shub/settings/local.py` that
+includes "pam_auth" to enable the login option.
 
 ```bash
 PLUGINS_ENABLED = [
-#    'ldap_auth',
     'pam_auth',
-#    'globus',
-#    'saml_auth'
 ]
 ```
 

--- a/docs/_docs/plugins/pgp/README.md
+++ b/docs/_docs/plugins/pgp/README.md
@@ -13,7 +13,7 @@ protocol, meaning that activating the plugin will expose "lookup" and "add" endp
 
 To enable the pgp plugin you must:
 
-  * Add `pgp` to the `PLUGINS_ENABLED` list in `shub/settings/config.py`
+  * Add `pgp` to the `PLUGINS_ENABLED` list in `shub/settings/local.py`
   * Build the docker image with the build argument ENABLE_PGP set to true:
     ```bash
     $ docker build --build-arg ENABLE_PGP=true -t quay.io/vanessa/sregistry .

--- a/docs/_docs/plugins/saml/README.md
+++ b/docs/_docs/plugins/saml/README.md
@@ -11,8 +11,8 @@ The `saml_auth` plugin allows users to authentication with your [SAML provider](
 
 To enable SAML authentication you must:
 
-  * Add `saml_auth` to the `PLUGINS_ENABLED` list in `shub/settings/config.py`
-  * Add some configuration details to `shub/settings/config.py`
+  * Add `saml_auth` to the `PLUGINS_ENABLED` list in `shub/settings/local.py`
+  * Add some configuration details to `shub/settings/local.py`
   * Configure the details of your SAML provider in in `shub/settings/secrets.py` per instructions provided [here](http://python-social-auth.readthedocs.io/en/latest/backends/saml.html).
   * Build the docker image with the build argument ENABLE_SAML set to true:
     ```bash
@@ -31,18 +31,10 @@ cp shub/settings/dummy_secrets.py shub/settings/secrets.py
 This quick start is intended to demonstrate basic functionality of the SAML authentication. 
 
 
-#### Edit Config.py
+#### Edit `local.py`
 
-In the file `shub/settings/config.py` you should add the name of your institution (used to render the button)
-along with the idp (the unique identifier for your SAML server request). That means uncommenting these lines.
-
-```bash
-# AUTH_SAML_IDP = "stanford"
-# AUTH_SAML_INSTITUTION = "Stanford University"
-```
-
-so they appear like:
-
+In the file `shub/settings/local.py` you should add the name of your institution (used to render the button)
+along with the idp (the unique identifier for your SAML server request). For example:
 
 ```bash
 AUTH_SAML_IDP = "stanford"

--- a/shub/settings/__init__.py
+++ b/shub/settings/__init__.py
@@ -8,6 +8,17 @@ from .logging import *
 from .main import *
 from .tasks import *
 
+# load any local overrides
+try:
+    from .secrets import *
+except ImportError:
+    pass
+
+try:
+    from .local import *
+except ImportError:
+    pass
+
 # If PAM_AUTH in plugins enbled, add django_pam
 if "pam_auth" in PLUGINS_ENABLED:
     INSTALLED_APPS += ["django_pam"]

--- a/shub/settings/main.py
+++ b/shub/settings/main.py
@@ -99,8 +99,3 @@ UPLOAD_PATH = "%s/_upload" % MEDIA_ROOT
 # Gravatar
 GRAVATAR_DEFAULT_IMAGE = "retro"
 # An image url or one of the following: 'mm', 'identicon', 'monsterid', 'wavatar', 'retro'. Defaults to 'mm'
-
-try:
-    from .secrets import *
-except ImportError:
-    pass


### PR DESCRIPTION
Improve the k8s deployment experience by making override updates to `settings/local.py` rather than changing the entire `settings/config.py`, like was done in the [helm templates](https://github.com/odatskov/helm-sregistry/blob/master/sregistry/templates/sregistry-cm.yaml#L19) referenced in https://github.com/singularityhub/sregistry/issues/317. A single container can now be built for use in dev/stg/prd environments and use an updated helm manifest to override values that differ in each env. This also improves the dev & upgrade experience by having local settings not pollute code under source control.

Pros/cons of this approach:
* Pro:
  * Backwards compatible (users can continue to make changes in `config.py` if they want).
  * Optional -- if there is no `local.py` everything continues to work.
  * Re-uses established pattern of using a python file that does not exist in the repo (eg `secrets.py`).
* Cons:
  * Changes the suggested location of where configurations are set (`local.py` vs `config.py`) requiring several doc updates.
  * Users must copy/paste/change the settings from `config.py` into `local.py`.

Other approaches considered:
* We could move to a config file or env-based approach. The challenge would be lots of changes to `config.py` to optionally read every variable from the file or env before falling back to a default/initial value. This approach is also challenging for representing non-string / non-numeric configuration settings (booleans, lists).
* All of this is technically not necessary as users can just write config values into `secret.py` and have them picked up and override `config.py`. This hacky approach convolutes the separation of secrets vs configuration data.